### PR TITLE
Dashboard message deck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^6.7.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.6",
+        "styled-icons": "^10.47.0",
         "use-local-storage-state": "^18.1.2",
         "web-vitals": "^2.1.4"
       }
@@ -3211,6 +3212,634 @@
       "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@styled-icons/bootstrap": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/bootstrap/-/bootstrap-10.47.0.tgz",
+      "integrity": "sha512-xpnPdrLhAhpTRE4iljQIEK73twVj7VPglwHSL+8nQdH7EsW5RJIOWsmlkZMyqhQHN0H7fGmT10F3/6OQhSpfGg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-logos": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.47.0.tgz",
+      "integrity": "sha512-eDZfiTjBth4MsCX83ZfiWIoYGU494NxZgAxyf7S0ky2ZRsJnq/Cs7crH4hKWUTaLvCo0XRJmLeA3Us2tZFiItg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-regular": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-regular/-/boxicons-regular-10.47.0.tgz",
+      "integrity": "sha512-z8KczDp4VArXvOn8i2j66Xs4oX9oiiJEhMoHydY3uC9kdtImcxhZ/xHPrgTJLkbK6f5ikwB4CKVnSqQGzzAJNw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-solid": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-solid/-/boxicons-solid-10.47.0.tgz",
+      "integrity": "sha512-M795TXYtSJCpfr+ukHZfH9mA0j5MPlB5vwRCnU3O+dojAYla/zoaSashjhUbmlgzKNwALWNfzOqicSCAzU2fhg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/crypto": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/crypto/-/crypto-10.47.0.tgz",
+      "integrity": "sha512-2hSOo1yb3ZEEOJAv9OBZLf3KQ8ujJrLw1uVDINJa7zLGuSfEWawnlkv/T2B0zQkOm0Hb6gikTRTAkLr4gyIS4Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/entypo": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo/-/entypo-10.46.0.tgz",
+      "integrity": "sha512-0ChIqx3EMlMeout4Aa5AwEYtKsgTqrY/NnVQGvhlGfMYq9mC7jq7JuaKvt5SJ9/0cEnVhgW5zwAe4LeyrsJl5g==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/entypo-social": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo-social/-/entypo-social-10.46.0.tgz",
+      "integrity": "sha512-DWbUK7JkuAu4TPIBeeYfxys3cP8M4/q/XG2JVruDHa18viCEcDR1JXfn1p3TVYZCvlciKev+Vr1yrgcamTwVkg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evaicons-outline": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-outline/-/evaicons-outline-10.46.0.tgz",
+      "integrity": "sha512-+tHb/Ir6G1e+rSJ2YKgm2vzjF80JoXWEmoC48exFrQEKQkJPSWtsqKdROkfANKrY9AFnRKhJQ+9fHhnjS+V/OA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evaicons-solid": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-solid/-/evaicons-solid-10.46.0.tgz",
+      "integrity": "sha512-tRw2/TkmRNV4N2badKPFnnRy+WbVtUkrloNo94CgF5rpxoL0eK+ki3OYZYqbl0T66bJ07hqduqTc3rbxvT/vfw==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evil": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evil/-/evil-10.46.0.tgz",
+      "integrity": "sha512-r1g2jZmz84XGLgJbAPkMDmuToUF+KyNWkS6GNoP+ygzriNgzgoHkcEvIb/bx/I2/UUHeotRMOknvhvh5C2CwFg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-brands": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.47.0.tgz",
+      "integrity": "sha512-w+G31+61nBnjxzCwMs+H9rNm9jl+HhtRgZYvNd+2NKQn1dRbHbBVXzQEHCOL6hksvkDbIa0iPrenqMU6pB+wZQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-regular": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.47.0.tgz",
+      "integrity": "sha512-UL/MwhwlJ5SbcioI+UBR8KocYt6i+20akKn1ZNj0Pjgm2kv2odEJSWWkHCxh8J7T7s0q/Wvs3CMsBTMrKdKDpQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-solid": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.47.0.tgz",
+      "integrity": "sha512-8AJjbOAkvPlB/ypFzWo++CZxRDlFQfvWQSjWzVU/v/4kjGRWIiVB+rJrTB7joDUd5Oas/se4cSiDkSA+XR/Fqg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/feather": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/feather/-/feather-10.47.0.tgz",
+      "integrity": "sha512-w6F3s1B4DaQGLr4AZZ0PffZQOnPSRqr3npHoTvk4Juz4uTjw9/oHolcrTxPyJas9gXAV1kCLbeiaxTR6JVxJPw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fluentui-system-filled": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-filled/-/fluentui-system-filled-10.47.0.tgz",
+      "integrity": "sha512-jAO8bs9SY/5Xu2vxg5sJmnD5YA966G2m2qU4ezlDbLDIXSaX/1qUBUivBFSWCDn4q5rslegzD1rhc9FncgPbSw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fluentui-system-regular": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-regular/-/fluentui-system-regular-10.47.0.tgz",
+      "integrity": "sha512-x1TmxKS6mpX+QJw8ismT3rNa6TPvKYftmQRy57LbdNE9L5FkyWldrumPboZGKWi/oNiBn6SBelPeqv8LPFXNHQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/foundation": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/foundation/-/foundation-10.46.0.tgz",
+      "integrity": "sha512-RZqNVxStjvboGg6+X1By9pE0j7FuzUkfgbu9SgOkSzMrHTvnTOu0JiQ7nNw+CY46rXhT8JTwRCgk2OLTk+anGA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/heroicons-outline": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-outline/-/heroicons-outline-10.47.0.tgz",
+      "integrity": "sha512-C7bcJ/YPVKACoQLSBDM9DkgmrO1HmqAaru9kqYK2V+GaGUW5raf6dyTLo7GUYt/CJ7p3qWxsBz3SX6djzdaODQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/heroicons-solid": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-solid/-/heroicons-solid-10.47.0.tgz",
+      "integrity": "sha512-j+tJx2NzLG2tc91IXJVwKNjsI/osxmak+wmLfnfBsB+49srpxMYjuLPMtl9ZY/xgbNsWO36O+/N5Zf5bkgiKcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/icomoon": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/icomoon/-/icomoon-10.46.0.tgz",
+      "integrity": "sha512-3KcTTuswDrC03byyr9G9v5aWDTrhO6PbbN5O7CtU4/NXY4AaOkTQ8GUfvRjZ8yG/aEYRH4VYkWFpYu1CdsZxNg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-outline": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-outline/-/ionicons-outline-10.46.0.tgz",
+      "integrity": "sha512-BEFEBGQDhPssEshbHyrsAXbEb7hNsrsHa0Zh0zLlfCIB3Vxc2GrQU9Qibto443ZRVw5qgF7iBdSwQHiwY8dQJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-sharp": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-sharp/-/ionicons-sharp-10.46.0.tgz",
+      "integrity": "sha512-ZMkS+zBe04odi/4llkKMZkNEz8K3whta7Chzk81vvCTtR7jMnGEyw+tMUZbARliOOyaELBeTbgeUwNRNTibiSA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-solid": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-solid/-/ionicons-solid-10.46.0.tgz",
+      "integrity": "sha512-agiuzQzqrrRWHrGfswC6EciKVjt/XSZuQFbvP/s6qU2oYkQuJRdhmAZQldTaj9Xb2GyAmEjM0cmkWG3+JzV7CQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material/-/material-10.47.0.tgz",
+      "integrity": "sha512-6fwoLPHg3P9O/iXSblQ67mchgURJvhU7mfba29ICfpg62zJ/loEalUgspm1GGtYVSPtkejshVWUtV99dXpcQfg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-outlined": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-outlined/-/material-outlined-10.47.0.tgz",
+      "integrity": "sha512-/QeDSGXlfRoIsgx4g4Hb//xhsucD4mJJsNPk/e1XzckxkNG+YHCIjbAHzDwxwNfSCJYcTDcOp2SZcoS7iyNGlw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-rounded": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-rounded/-/material-rounded-10.47.0.tgz",
+      "integrity": "sha512-+ByhDd1FJept3k8iBDxMWSzmIh29UrgZTIzh2pADWldGrsD/2JKdsC7knQghSj9uCevHNMKEeVaYBQMLoNUjvw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-sharp": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-sharp/-/material-sharp-10.47.0.tgz",
+      "integrity": "sha512-U9bjvur/vawfiBhE75efNOF4WkSAygn26bQvHFJPc71ZCisvgJncnlSmR0rUgWnu7Cp/qg6faDH5CKDXBmGWCA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-twotone": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-twotone/-/material-twotone-10.47.0.tgz",
+      "integrity": "sha512-c4Q1r0EJaDEI1/IsBWo0Mo8lZZvtA/3Or1ScUcmjwKBZxpR8960uGy4CReLzBPALC4L6aPiM1H168fz39fm4oQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/octicons": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/octicons/-/octicons-10.47.0.tgz",
+      "integrity": "sha512-JOqEbwbh23u/AdaINod8ZeVN5MEcOvkSeMTwGIPaPgz5PNuWRj/+1LpixmBeZjAr/WhB0pxZBBwA+e91BelQCA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/open-iconic": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/open-iconic/-/open-iconic-10.46.0.tgz",
+      "integrity": "sha512-v7wrHcUACQeSfJrLan/jXxgz7RSlJJXSc2u33UR82ewkOSBhaXp/zZxKF1tFCT2spvth0NBl6OkZUCw9ctgyrA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/remix-editor": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-editor/-/remix-editor-10.46.0.tgz",
+      "integrity": "sha512-oOrt6wj5//4LrZkm40bXcsFpTgXbdOkixu6RHuE3O82+Hqtw1bYR/smm5MbLOJ+Kz62SEjDF3sxqFO23ITDeUQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/remix-fill": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-fill/-/remix-fill-10.46.0.tgz",
+      "integrity": "sha512-D2rWGJ9/7BR+3TMvmIoWGASMfyhWT4lTF+we8h9Pya5Ye+69cftvp817DMuaR/6czCugXTrB++HTQX0XJfoBFw==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/remix-line": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-line/-/remix-line-10.46.0.tgz",
+      "integrity": "sha512-TkbtXdgcuM7VpE/51k8+sxfReFjSQpAFVnjJi8/gxwcTzjdOG7Plkgsaixi2+hiLk/Coj/+67KbntBoSevROsw==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/simple-icons": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.46.0.tgz",
+      "integrity": "sha512-zHkbGqAqFOwpqDjbhKTKsAXNxtBOXb7Ot2eKoDaDFckJGr2shAXRchclUS6wSixSPwQIPGAUcdO7Cq744Ollng==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/styled-icon": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/styled-icon/-/styled-icon-10.7.0.tgz",
+      "integrity": "sha512-SCrhCfRyoY8DY7gUkpz+B0RqUg/n1Zaqrr2+YKmK/AyeNfCcoHuP4R9N4H0p/NA1l7PTU10ZkAWSLi68phnAjw==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": ">=4.1.0 <6"
+      }
+    },
+    "node_modules/@styled-icons/typicons": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/typicons/-/typicons-10.46.0.tgz",
+      "integrity": "sha512-yCJnVggGsbxOyuIPEmD+9IYRvB5w41hpJKdpI0ErasYG9Izt/lGqUaaDaxR39u9s28Q54Fq/v+Ni17dFCs8FOw==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/zondicons": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/zondicons/-/zondicons-10.46.0.tgz",
+      "integrity": "sha512-DUlww6TeFsFjHD/1qd+DtMutm44r3ssOYtPiMJrOVolX1NqdW6XzrJ5dTbVCA2s7Ucd+Vp25cWfXnLcJBfas3w==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -15596,6 +16225,59 @@
         "react-is": ">= 16.8.0"
       }
     },
+    "node_modules/styled-icons": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.47.0.tgz",
+      "integrity": "sha512-tMdhM1kB8qJEf1TLrZrPiVqfODEe4JjbqTJ5mGAyJOCnqC3BvqGwL5q30xuWeU2gqGPwyFfgrQM9nupka55IGw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/bootstrap": "10.47.0",
+        "@styled-icons/boxicons-logos": "10.47.0",
+        "@styled-icons/boxicons-regular": "10.47.0",
+        "@styled-icons/boxicons-solid": "10.47.0",
+        "@styled-icons/crypto": "10.47.0",
+        "@styled-icons/entypo": "10.46.0",
+        "@styled-icons/entypo-social": "10.46.0",
+        "@styled-icons/evaicons-outline": "10.46.0",
+        "@styled-icons/evaicons-solid": "10.46.0",
+        "@styled-icons/evil": "10.46.0",
+        "@styled-icons/fa-brands": "10.47.0",
+        "@styled-icons/fa-regular": "10.47.0",
+        "@styled-icons/fa-solid": "10.47.0",
+        "@styled-icons/feather": "10.47.0",
+        "@styled-icons/fluentui-system-filled": "10.47.0",
+        "@styled-icons/fluentui-system-regular": "10.47.0",
+        "@styled-icons/foundation": "10.46.0",
+        "@styled-icons/heroicons-outline": "10.47.0",
+        "@styled-icons/heroicons-solid": "10.47.0",
+        "@styled-icons/icomoon": "10.46.0",
+        "@styled-icons/ionicons-outline": "10.46.0",
+        "@styled-icons/ionicons-sharp": "10.46.0",
+        "@styled-icons/ionicons-solid": "10.46.0",
+        "@styled-icons/material": "10.47.0",
+        "@styled-icons/material-outlined": "10.47.0",
+        "@styled-icons/material-rounded": "10.47.0",
+        "@styled-icons/material-sharp": "10.47.0",
+        "@styled-icons/material-twotone": "10.47.0",
+        "@styled-icons/octicons": "10.47.0",
+        "@styled-icons/open-iconic": "10.46.0",
+        "@styled-icons/remix-editor": "10.46.0",
+        "@styled-icons/remix-fill": "10.46.0",
+        "@styled-icons/remix-line": "10.46.0",
+        "@styled-icons/simple-icons": "10.46.0",
+        "@styled-icons/styled-icon": "10.7.0",
+        "@styled-icons/typicons": "10.46.0",
+        "@styled-icons/zondicons": "10.46.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": ">=4.1.0 <6"
+      }
+    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
@@ -19455,6 +20137,338 @@
       "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@styled-icons/bootstrap": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/bootstrap/-/bootstrap-10.47.0.tgz",
+      "integrity": "sha512-xpnPdrLhAhpTRE4iljQIEK73twVj7VPglwHSL+8nQdH7EsW5RJIOWsmlkZMyqhQHN0H7fGmT10F3/6OQhSpfGg==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/boxicons-logos": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.47.0.tgz",
+      "integrity": "sha512-eDZfiTjBth4MsCX83ZfiWIoYGU494NxZgAxyf7S0ky2ZRsJnq/Cs7crH4hKWUTaLvCo0XRJmLeA3Us2tZFiItg==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/boxicons-regular": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-regular/-/boxicons-regular-10.47.0.tgz",
+      "integrity": "sha512-z8KczDp4VArXvOn8i2j66Xs4oX9oiiJEhMoHydY3uC9kdtImcxhZ/xHPrgTJLkbK6f5ikwB4CKVnSqQGzzAJNw==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/boxicons-solid": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-solid/-/boxicons-solid-10.47.0.tgz",
+      "integrity": "sha512-M795TXYtSJCpfr+ukHZfH9mA0j5MPlB5vwRCnU3O+dojAYla/zoaSashjhUbmlgzKNwALWNfzOqicSCAzU2fhg==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/crypto": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/crypto/-/crypto-10.47.0.tgz",
+      "integrity": "sha512-2hSOo1yb3ZEEOJAv9OBZLf3KQ8ujJrLw1uVDINJa7zLGuSfEWawnlkv/T2B0zQkOm0Hb6gikTRTAkLr4gyIS4Q==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/entypo": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo/-/entypo-10.46.0.tgz",
+      "integrity": "sha512-0ChIqx3EMlMeout4Aa5AwEYtKsgTqrY/NnVQGvhlGfMYq9mC7jq7JuaKvt5SJ9/0cEnVhgW5zwAe4LeyrsJl5g==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/entypo-social": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo-social/-/entypo-social-10.46.0.tgz",
+      "integrity": "sha512-DWbUK7JkuAu4TPIBeeYfxys3cP8M4/q/XG2JVruDHa18viCEcDR1JXfn1p3TVYZCvlciKev+Vr1yrgcamTwVkg==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/evaicons-outline": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-outline/-/evaicons-outline-10.46.0.tgz",
+      "integrity": "sha512-+tHb/Ir6G1e+rSJ2YKgm2vzjF80JoXWEmoC48exFrQEKQkJPSWtsqKdROkfANKrY9AFnRKhJQ+9fHhnjS+V/OA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/evaicons-solid": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-solid/-/evaicons-solid-10.46.0.tgz",
+      "integrity": "sha512-tRw2/TkmRNV4N2badKPFnnRy+WbVtUkrloNo94CgF5rpxoL0eK+ki3OYZYqbl0T66bJ07hqduqTc3rbxvT/vfw==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/evil": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evil/-/evil-10.46.0.tgz",
+      "integrity": "sha512-r1g2jZmz84XGLgJbAPkMDmuToUF+KyNWkS6GNoP+ygzriNgzgoHkcEvIb/bx/I2/UUHeotRMOknvhvh5C2CwFg==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/fa-brands": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.47.0.tgz",
+      "integrity": "sha512-w+G31+61nBnjxzCwMs+H9rNm9jl+HhtRgZYvNd+2NKQn1dRbHbBVXzQEHCOL6hksvkDbIa0iPrenqMU6pB+wZQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/fa-regular": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.47.0.tgz",
+      "integrity": "sha512-UL/MwhwlJ5SbcioI+UBR8KocYt6i+20akKn1ZNj0Pjgm2kv2odEJSWWkHCxh8J7T7s0q/Wvs3CMsBTMrKdKDpQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/fa-solid": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.47.0.tgz",
+      "integrity": "sha512-8AJjbOAkvPlB/ypFzWo++CZxRDlFQfvWQSjWzVU/v/4kjGRWIiVB+rJrTB7joDUd5Oas/se4cSiDkSA+XR/Fqg==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/feather": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/feather/-/feather-10.47.0.tgz",
+      "integrity": "sha512-w6F3s1B4DaQGLr4AZZ0PffZQOnPSRqr3npHoTvk4Juz4uTjw9/oHolcrTxPyJas9gXAV1kCLbeiaxTR6JVxJPw==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/fluentui-system-filled": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-filled/-/fluentui-system-filled-10.47.0.tgz",
+      "integrity": "sha512-jAO8bs9SY/5Xu2vxg5sJmnD5YA966G2m2qU4ezlDbLDIXSaX/1qUBUivBFSWCDn4q5rslegzD1rhc9FncgPbSw==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/fluentui-system-regular": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-regular/-/fluentui-system-regular-10.47.0.tgz",
+      "integrity": "sha512-x1TmxKS6mpX+QJw8ismT3rNa6TPvKYftmQRy57LbdNE9L5FkyWldrumPboZGKWi/oNiBn6SBelPeqv8LPFXNHQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/foundation": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/foundation/-/foundation-10.46.0.tgz",
+      "integrity": "sha512-RZqNVxStjvboGg6+X1By9pE0j7FuzUkfgbu9SgOkSzMrHTvnTOu0JiQ7nNw+CY46rXhT8JTwRCgk2OLTk+anGA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/heroicons-outline": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-outline/-/heroicons-outline-10.47.0.tgz",
+      "integrity": "sha512-C7bcJ/YPVKACoQLSBDM9DkgmrO1HmqAaru9kqYK2V+GaGUW5raf6dyTLo7GUYt/CJ7p3qWxsBz3SX6djzdaODQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/heroicons-solid": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-solid/-/heroicons-solid-10.47.0.tgz",
+      "integrity": "sha512-j+tJx2NzLG2tc91IXJVwKNjsI/osxmak+wmLfnfBsB+49srpxMYjuLPMtl9ZY/xgbNsWO36O+/N5Zf5bkgiKcQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/icomoon": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/icomoon/-/icomoon-10.46.0.tgz",
+      "integrity": "sha512-3KcTTuswDrC03byyr9G9v5aWDTrhO6PbbN5O7CtU4/NXY4AaOkTQ8GUfvRjZ8yG/aEYRH4VYkWFpYu1CdsZxNg==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/ionicons-outline": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-outline/-/ionicons-outline-10.46.0.tgz",
+      "integrity": "sha512-BEFEBGQDhPssEshbHyrsAXbEb7hNsrsHa0Zh0zLlfCIB3Vxc2GrQU9Qibto443ZRVw5qgF7iBdSwQHiwY8dQJw==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/ionicons-sharp": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-sharp/-/ionicons-sharp-10.46.0.tgz",
+      "integrity": "sha512-ZMkS+zBe04odi/4llkKMZkNEz8K3whta7Chzk81vvCTtR7jMnGEyw+tMUZbARliOOyaELBeTbgeUwNRNTibiSA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/ionicons-solid": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-solid/-/ionicons-solid-10.46.0.tgz",
+      "integrity": "sha512-agiuzQzqrrRWHrGfswC6EciKVjt/XSZuQFbvP/s6qU2oYkQuJRdhmAZQldTaj9Xb2GyAmEjM0cmkWG3+JzV7CQ==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/material": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material/-/material-10.47.0.tgz",
+      "integrity": "sha512-6fwoLPHg3P9O/iXSblQ67mchgURJvhU7mfba29ICfpg62zJ/loEalUgspm1GGtYVSPtkejshVWUtV99dXpcQfg==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/material-outlined": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-outlined/-/material-outlined-10.47.0.tgz",
+      "integrity": "sha512-/QeDSGXlfRoIsgx4g4Hb//xhsucD4mJJsNPk/e1XzckxkNG+YHCIjbAHzDwxwNfSCJYcTDcOp2SZcoS7iyNGlw==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/material-rounded": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-rounded/-/material-rounded-10.47.0.tgz",
+      "integrity": "sha512-+ByhDd1FJept3k8iBDxMWSzmIh29UrgZTIzh2pADWldGrsD/2JKdsC7knQghSj9uCevHNMKEeVaYBQMLoNUjvw==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/material-sharp": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-sharp/-/material-sharp-10.47.0.tgz",
+      "integrity": "sha512-U9bjvur/vawfiBhE75efNOF4WkSAygn26bQvHFJPc71ZCisvgJncnlSmR0rUgWnu7Cp/qg6faDH5CKDXBmGWCA==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/material-twotone": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-twotone/-/material-twotone-10.47.0.tgz",
+      "integrity": "sha512-c4Q1r0EJaDEI1/IsBWo0Mo8lZZvtA/3Or1ScUcmjwKBZxpR8960uGy4CReLzBPALC4L6aPiM1H168fz39fm4oQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/octicons": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/octicons/-/octicons-10.47.0.tgz",
+      "integrity": "sha512-JOqEbwbh23u/AdaINod8ZeVN5MEcOvkSeMTwGIPaPgz5PNuWRj/+1LpixmBeZjAr/WhB0pxZBBwA+e91BelQCA==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/open-iconic": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/open-iconic/-/open-iconic-10.46.0.tgz",
+      "integrity": "sha512-v7wrHcUACQeSfJrLan/jXxgz7RSlJJXSc2u33UR82ewkOSBhaXp/zZxKF1tFCT2spvth0NBl6OkZUCw9ctgyrA==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/remix-editor": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-editor/-/remix-editor-10.46.0.tgz",
+      "integrity": "sha512-oOrt6wj5//4LrZkm40bXcsFpTgXbdOkixu6RHuE3O82+Hqtw1bYR/smm5MbLOJ+Kz62SEjDF3sxqFO23ITDeUQ==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/remix-fill": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-fill/-/remix-fill-10.46.0.tgz",
+      "integrity": "sha512-D2rWGJ9/7BR+3TMvmIoWGASMfyhWT4lTF+we8h9Pya5Ye+69cftvp817DMuaR/6czCugXTrB++HTQX0XJfoBFw==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/remix-line": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-line/-/remix-line-10.46.0.tgz",
+      "integrity": "sha512-TkbtXdgcuM7VpE/51k8+sxfReFjSQpAFVnjJi8/gxwcTzjdOG7Plkgsaixi2+hiLk/Coj/+67KbntBoSevROsw==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/simple-icons": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.46.0.tgz",
+      "integrity": "sha512-zHkbGqAqFOwpqDjbhKTKsAXNxtBOXb7Ot2eKoDaDFckJGr2shAXRchclUS6wSixSPwQIPGAUcdO7Cq744Ollng==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/styled-icon": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/styled-icon/-/styled-icon-10.7.0.tgz",
+      "integrity": "sha512-SCrhCfRyoY8DY7gUkpz+B0RqUg/n1Zaqrr2+YKmK/AyeNfCcoHuP4R9N4H0p/NA1l7PTU10ZkAWSLi68phnAjw==",
+      "requires": {
+        "@babel/runtime": "^7.19.0"
+      }
+    },
+    "@styled-icons/typicons": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/typicons/-/typicons-10.46.0.tgz",
+      "integrity": "sha512-yCJnVggGsbxOyuIPEmD+9IYRvB5w41hpJKdpI0ErasYG9Izt/lGqUaaDaxR39u9s28Q54Fq/v+Ni17dFCs8FOw==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
+      }
+    },
+    "@styled-icons/zondicons": {
+      "version": "10.46.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/zondicons/-/zondicons-10.46.0.tgz",
+      "integrity": "sha512-DUlww6TeFsFjHD/1qd+DtMutm44r3ssOYtPiMJrOVolX1NqdW6XzrJ5dTbVCA2s7Ucd+Vp25cWfXnLcJBfas3w==",
+      "requires": {
+        "@babel/runtime": "^7.19.0",
+        "@styled-icons/styled-icon": "^10.7.0"
       }
     },
     "@surma/rollup-plugin-off-main-thread": {
@@ -28304,6 +29318,51 @@
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
+      }
+    },
+    "styled-icons": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.47.0.tgz",
+      "integrity": "sha512-tMdhM1kB8qJEf1TLrZrPiVqfODEe4JjbqTJ5mGAyJOCnqC3BvqGwL5q30xuWeU2gqGPwyFfgrQM9nupka55IGw==",
+      "requires": {
+        "@babel/runtime": "^7.20.7",
+        "@styled-icons/bootstrap": "10.47.0",
+        "@styled-icons/boxicons-logos": "10.47.0",
+        "@styled-icons/boxicons-regular": "10.47.0",
+        "@styled-icons/boxicons-solid": "10.47.0",
+        "@styled-icons/crypto": "10.47.0",
+        "@styled-icons/entypo": "10.46.0",
+        "@styled-icons/entypo-social": "10.46.0",
+        "@styled-icons/evaicons-outline": "10.46.0",
+        "@styled-icons/evaicons-solid": "10.46.0",
+        "@styled-icons/evil": "10.46.0",
+        "@styled-icons/fa-brands": "10.47.0",
+        "@styled-icons/fa-regular": "10.47.0",
+        "@styled-icons/fa-solid": "10.47.0",
+        "@styled-icons/feather": "10.47.0",
+        "@styled-icons/fluentui-system-filled": "10.47.0",
+        "@styled-icons/fluentui-system-regular": "10.47.0",
+        "@styled-icons/foundation": "10.46.0",
+        "@styled-icons/heroicons-outline": "10.47.0",
+        "@styled-icons/heroicons-solid": "10.47.0",
+        "@styled-icons/icomoon": "10.46.0",
+        "@styled-icons/ionicons-outline": "10.46.0",
+        "@styled-icons/ionicons-sharp": "10.46.0",
+        "@styled-icons/ionicons-solid": "10.46.0",
+        "@styled-icons/material": "10.47.0",
+        "@styled-icons/material-outlined": "10.47.0",
+        "@styled-icons/material-rounded": "10.47.0",
+        "@styled-icons/material-sharp": "10.47.0",
+        "@styled-icons/material-twotone": "10.47.0",
+        "@styled-icons/octicons": "10.47.0",
+        "@styled-icons/open-iconic": "10.46.0",
+        "@styled-icons/remix-editor": "10.46.0",
+        "@styled-icons/remix-fill": "10.46.0",
+        "@styled-icons/remix-line": "10.46.0",
+        "@styled-icons/simple-icons": "10.46.0",
+        "@styled-icons/styled-icon": "10.7.0",
+        "@styled-icons/typicons": "10.46.0",
+        "@styled-icons/zondicons": "10.46.0"
       }
     },
     "stylehacks": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-router-dom": "^6.7.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6",
+    "styled-icons": "^10.47.0",
     "use-local-storage-state": "^18.1.2",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,11 @@ const router = createBrowserRouter(
         element={<Dashboard />}
         errorElement={<ErrorPage />}
       />
+      {/* <Route
+        path="/friends"
+        element={<Friends />}
+        errorElement={<ErrorPage />}
+      /> */}
     </Route>
   )
 )

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -4,11 +4,14 @@ import { ChatContext } from '../context/ChatContext'
 import { FriendContext } from '../context/FriendContext'
 import { device } from '../worker/breakpoints'
 import { Friends } from '../worker/FakeData'
-import { TbMessageCircle2 } from 'react-icons/tb'
+import { TbMessageCircle2, TbDoorExit } from 'react-icons/tb'
+import { FaTimes } from 'react-icons/fa'
 import { Link } from 'react-router-dom'
 import UserMenu from './UserMenu'
 import FriendModal from './FriendModal'
-
+// import { Close } from '@styled-icons/zondicons'
+import { Close } from '@styled-icons/material-rounded'
+// @styled-icons/zondicons/Close
 const ConditionalNav = styled.section`
   margin: 0;
   border: solid 3px #505050;
@@ -112,22 +115,7 @@ const Messages = styled.p`
   top: -1vh;
   margin-left: 1em;
   font-size: 100%;
-  &:hover {
-    cursor: context-menu;
-  }
   margin-right: 1em;
-  // @media only screen and ${device.xs} {
-  //   font-size: 100%;
-  // }
-  // @media only screen and ${device.sm} {
-  //   font-size: 100%;
-  // }
-  // @media only screen and ${device.md} {
-  //   font-size: 100%;
-  // }
-  // @media only screen and ${device.lg} {
-  //   font-size: 100%;
-  // }
 `
 
 const Badge = styled(TbMessageCircle2)`
@@ -195,6 +183,19 @@ const Inbox = styled.h1`
   color: #ffffff;
   // cursor: context-menu;
 `
+const CloseInbox = styled(FaTimes)`
+  display: flex;
+  position: absolute;
+  top: 30%;
+  right: 10%;
+  font-size: 2.5vw;
+  // color: #ffffff;
+  cursor: pointer;
+  color: #ffffff;
+  // background-color: #ffffff;
+
+`
+
 const HeaderDiv = styled.div`
   display: flex;
   position: sticky;
@@ -324,6 +325,7 @@ const ConditionalNavBar = () => {
       <ConditionalNav open={openChat}>
         <HeaderDiv>
           <Inbox>Inbox</Inbox>
+          <CloseInbox onClick={handleChatStateChange} />
         </HeaderDiv>
         <FriendContainer>
           {Friends.map(

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -21,6 +21,7 @@ const ConditionalNav = styled.section`
   // width: 500%;
   padding: 5em;
   border-radius: 8px;
+  flex-grow: 1;
   @media only screen and ${device.xs} {
     display: none;
   }
@@ -53,6 +54,10 @@ const ConditionalNav = styled.section`
 const NavbarLink = styled(Link)`
   color: #ffffff;
   display: flex;
+  position: relative;
+  // position: absolute;
+  // left: 1%;
+  left: 1%;
   font-style: normal;
   font-weight: 700;
   margin-left: 0.5em;
@@ -80,6 +85,49 @@ const NavbarLink = styled(Link)`
     font-size: large;
     margin-left: 2em;
   }
+`
+
+const User = styled.h1`
+  position: relative;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 200%;
+  margin-left: 1.5em;
+  margin-top: -5em;
+  display: flex;
+  top: -5vh;
+  margin-top: 0;
+  padding: 0;
+  right: 0;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 180%;
+  margin-bottom: 0;
+`
+
+const Messages = styled.p`
+  display: flex;
+  color: #ffffff;
+  position: relative;
+  top: -1vh;
+  margin-left: 1em;
+  font-size: 100%;
+  &:hover {
+    cursor: context-menu;
+  }
+  margin-right: 1em;
+  // @media only screen and ${device.xs} {
+  //   font-size: 100%;
+  // }
+  // @media only screen and ${device.sm} {
+  //   font-size: 100%;
+  // }
+  // @media only screen and ${device.md} {
+  //   font-size: 100%;
+  // }
+  // @media only screen and ${device.lg} {
+  //   font-size: 100%;
+  // }
 `
 
 const Badge = styled(TbMessageCircle2)`
@@ -133,10 +181,10 @@ const BadgeNumber = styled.p`
 const Inbox = styled.h1`
   display: flex;
   position: absolute;
-  margin-top: 0;
+  margin-top: 1vh;
   padding: 0;
   margin: 0;
-  top: 5%;
+  top: 25%;
   left: 5%;
   font-size: 200%;
   width: 100%;
@@ -144,12 +192,12 @@ const Inbox = styled.h1`
   padding-top: 0px;
   margin-top: 0;
   margin-bottom: 0;
-  // border-bottom: solid 1px dimgrey;
   color: #ffffff;
-  cursor: context-menu;
+  // cursor: context-menu;
 `
 const HeaderDiv = styled.div`
   display: flex;
+  position: sticky;
   margin-left: -125%;
   margin-top: -125%; 
   width: 500%;
@@ -166,22 +214,71 @@ const HeaderDiv = styled.div`
 const FriendContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 500%;
-  // background: #696969;
+  margin: 0 auto;
   background-opacity: 20%;
+  max-height: 23vh;
   padding: 4em;
-  max-width: 10em;
-  padding-bottom: 4.4em;
-  padding-right: 0;
+  max-width: 6em;
   margin-left: -125%;
+  margin-bottom: -125%;
   border-radius: 5px;
+  overflow: scroll;
+  scroll-behavior: smooth;
+`
+
+const FriendCell = styled.div`
+  width: 16.4vw;
+  position: relative;
+  left: -5vw;
+  padding-top: 1em;
+  top: -10vh;
+  border-bottom: solid 1px #696969;
+  padding-left: 1em;
+  margin: 0 auto;
+  max-height: 10vh;
+`
+
+const Avatar = styled.img`
+  display: block;
+  border-radius: 50%;
+  position: relative;
+  left: 0.1em;
+  width: 2em;
+  height: 2em;
+  margin-top: 0;
+  margin-bottom: 0;
+  cursor: pointer;
+`
+
+const Timestamp = styled.p`
+  color: #ffffff;
+  position: absolute;
+  top: 6vh;
+  // border: 1px solid red;
+  // margin-left: 2.3em;
+  // margin-top: -3vh;
+  font-size: small;
+  // &:hover {
+  //   cursor: context-menu;
+  // }
+  // @media only screen and ${device.xs} {
+  //   margin-left: 1.5em;
+  // }
+  // @media only screen and ${device.sm} {
+  //   margin-left: 1.5em;
+  // }
+  // @media only screen and ${device.md} {
+  //   margin-left: 2.3em;
+  // }
+  // @media only screen and ${device.lg} {
+  //   margin-left: 2.3em;
+  // }
 `
 function handleProps(props) {
   return props.open === true ? `flex` : `none`
 }
 
 const ConditionalNavBar = () => {
-  const { handleNotifCount } = useContext(FriendContext)
   const {
     handleChatStateChange,
     openChat,
@@ -190,8 +287,15 @@ const ConditionalNavBar = () => {
     setNav,
     nav,
   } = useContext(ChatContext)
-  const { setFriendName, setAvatar, setOffsetLeft, setOffsetTop, getUnread } =
-    useContext(FriendContext)
+  const {
+    setFriendName,
+    setAvatar,
+    setOffsetLeft,
+    setOffsetTop,
+    getUnread,
+    unreadMessages,
+    handleNotifCount,
+  } = useContext(FriendContext)
 
   function handleMouseOver(id, name, avatar, i) {
     setNav('conditional')
@@ -223,25 +327,28 @@ const ConditionalNavBar = () => {
         </HeaderDiv>
         <FriendContainer>
           {Friends.map(
-            ({ name, id, avatar, unread, online }, i) =>
+            ({ name, id, avatar, unread, messages, online, timestamp }, i) =>
               online === '1' &&
               unread > 0 && (
                 <>
-                  <NavbarLink
+                  <FriendCell
                     ref={(ref) => {
                       friendRefs.current[i] = ref
                     }}
                     key={id}
-                    onMouseOver={() => handleMouseOver(id, name, avatar, i)}
-                    onMouseOut={handleMouseOut}
-                    onClick={handleChatStateChange}
+                    // onClick={handleChatStateChange}
                   >
-                    {name}
-                  </NavbarLink>
-                  {unread > 0 && <Badge />}
-                  {unread > 0 && (
-                    <BadgeNumber>{handleNotifCount(unread)}</BadgeNumber>
-                  )}
+                    <Avatar src={avatar} />
+                    <User
+
+                    // onMouseOver={() => handleMouseOver(id, name, avatar, i)}
+                    // onMouseOut={handleMouseOut}
+                    // onClick={handleChatStateChange}
+                    >
+                      {name}
+                    </User>
+                    <Timestamp>{messages[0].timestamp}</Timestamp>
+                  </FriendCell>
                 </>
               )
           )}

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -51,9 +51,10 @@ const ConditionalNav = styled.div`
 
 const NavbarLink = styled(Link)`
   color: #ffffff;
+  display: flex;
   font-style: normal;
   font-weight: 700;
-  margin-left: 2em;
+  margin-left: 0.5em;
   text-decoration: none;
   margin-top: 0.5em;
   margin-bottom: auto;
@@ -130,10 +131,16 @@ function handleProps(props) {
   return props.open === true ? `flex` : `none`
 }
 
-const ConditionalNavBar = ({}) => {
-  const [open, setOpen] = useState(false)
+const ConditionalNavBar = () => {
   const { handleNotifCount } = useContext(FriendContext)
-  const { handleChatStateChange, openChat } = useContext(ChatContext)
+  const {
+    handleChatStateChange,
+    openChat,
+    openMiniModal,
+    setOpenMini,
+    setNav,
+    nav
+  } = useContext(ChatContext)
   const { setFriendName, setAvatar, setOffsetLeft, setOffsetTop, getUnread } =
     useContext(FriendContext)
   /*
@@ -143,8 +150,9 @@ const ConditionalNavBar = ({}) => {
    */
 
   function handleMouseOver(id, name, avatar, i) {
+    setNav('conditional')
     getUnread(id, Friends)
-    setOpen(true)
+    setOpenMini(true)
     setFriendName(name)
     setAvatar(avatar)
     setOffsetLeft(friendRefs.current[i].offsetLeft)
@@ -152,7 +160,8 @@ const ConditionalNavBar = ({}) => {
   }
 
   const handleMouseOut = () => {
-    setOpen(false)
+    setOpenMini(false)
+    setOpenMini(false)
     setFriendName('')
     setAvatar('')
     setOffsetLeft(0)
@@ -163,6 +172,7 @@ const ConditionalNavBar = ({}) => {
 
   return (
     <>
+      {openMiniModal && <FriendModal nav={nav} />}
       <ConditionalNav open={openChat}>
         {Friends.map(
           ({ name, id, avatar, unread, online }, i) =>
@@ -187,7 +197,6 @@ const ConditionalNavBar = ({}) => {
               </>
             )
         )}
-        {open && <FriendModal />}
         {/* <UserMenu username={username} setUsername={setUsername} /> */}
       </ConditionalNav>
     </>

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -9,15 +9,16 @@ import { Link } from 'react-router-dom'
 import UserMenu from './UserMenu'
 import FriendModal from './FriendModal'
 
-const ConditionalNav = styled.div`
+const ConditionalNav = styled.section`
+  margin: 0;
   border: solid 3px #505050;
   background: #404040;
   position: fixed;
   flex-direction: column;
   right: 7vw;
   top: 32vh;
-  width: 5vw;
-  height: 25vh;
+  height: 30vh;
+  // width: 500%;
   padding: 5em;
   border-radius: 8px;
   @media only screen and ${device.xs} {
@@ -82,6 +83,7 @@ const NavbarLink = styled(Link)`
 `
 
 const Badge = styled(TbMessageCircle2)`
+  display: flex;
   color: #ffffff;
   margin-top: -1.5em;
   font-size: 1rem;
@@ -103,6 +105,7 @@ const Badge = styled(TbMessageCircle2)`
 `
 
 const BadgeNumber = styled.p`
+  dislay: flex;
   margin-left: 2.2em;
   margin-top: -1.6em;
   font-size: 0.6em;
@@ -127,6 +130,59 @@ const BadgeNumber = styled.p`
   }
 `
 
+const Inbox = styled.h1`
+  display: flex;
+  position: absolute;
+  margin-top: 0;
+  padding: 0;
+  margin: 0;
+  top: 5%;
+  left: 5%;
+  font-size: 200%;
+  width: 100%;
+  padding-bottom: 0px;
+  padding-top: 0px;
+  margin-top: 0;
+  margin-bottom: 0;
+  // border-bottom: solid 1px dimgrey;
+  color: #ffffff;
+  cursor: context-menu;
+`
+const HeaderDiv = styled.div`
+  display: flex;
+  // position: relative;
+  margin-left: -125%;
+  margin-top: -125%; 
+  width: 500%;
+  // border: outset 1px dimgrey;
+  border-bottom: groove 1px dimgrey;
+  background-color: DimGrey;
+  padding-top: 0vh;
+  padding 5em;
+  padding-bottom: 0vh;
+  height: auto;
+  max-width: 4em;
+  max-height: 1em;
+  border-radius: 5px;
+`
+
+const FriendContainer = styled.div`
+  // margin-top: 4em;
+  display: flex;
+  flex-direction: column;
+  width: 500%;
+  // position: fixed;
+  // background: #696969;
+  padding: 4em;
+  max-width: 10em;
+  padding-bottom: 4.4em;
+  // max-width: 4em;
+  padding-right: 0;
+  margin-left: -125%;
+  // padding-right: 0;
+  border-radius: 5px;
+  // border-top: groove 1px dimgrey;
+`
 function handleProps(props) {
   return props.open === true ? `flex` : `none`
 }
@@ -139,15 +195,10 @@ const ConditionalNavBar = () => {
     openMiniModal,
     setOpenMini,
     setNav,
-    nav
+    nav,
   } = useContext(ChatContext)
   const { setFriendName, setAvatar, setOffsetLeft, setOffsetTop, getUnread } =
     useContext(FriendContext)
-  /*
-    handleMouseOver and handleMouseOut funtsions handle the
-    hover events for displaying the modal and 
-    setting required data for modal.
-   */
 
   function handleMouseOver(id, name, avatar, i) {
     setNav('conditional')
@@ -174,29 +225,34 @@ const ConditionalNavBar = () => {
     <>
       {openMiniModal && <FriendModal nav={nav} />}
       <ConditionalNav open={openChat}>
-        {Friends.map(
-          ({ name, id, avatar, unread, online }, i) =>
-            online === '1' &&
-            unread > 0 && (
-              <>
-                <NavbarLink
-                  ref={(ref) => {
-                    friendRefs.current[i] = ref
-                  }}
-                  key={id}
-                  onMouseOver={() => handleMouseOver(id, name, avatar, i)}
-                  onMouseOut={handleMouseOut}
-                  onClick={handleChatStateChange}
-                >
-                  {name}
-                </NavbarLink>
-                {unread > 0 && <Badge />}
-                {unread > 0 && (
-                  <BadgeNumber>{handleNotifCount(unread)}</BadgeNumber>
-                )}
-              </>
-            )
-        )}
+        <HeaderDiv>
+          <Inbox>Inbox</Inbox>
+        </HeaderDiv>
+        <FriendContainer>
+          {Friends.map(
+            ({ name, id, avatar, unread, online }, i) =>
+              online === '1' &&
+              unread > 0 && (
+                <>
+                  <NavbarLink
+                    ref={(ref) => {
+                      friendRefs.current[i] = ref
+                    }}
+                    key={id}
+                    onMouseOver={() => handleMouseOver(id, name, avatar, i)}
+                    onMouseOut={handleMouseOut}
+                    onClick={handleChatStateChange}
+                  >
+                    {name}
+                  </NavbarLink>
+                  {unread > 0 && <Badge />}
+                  {unread > 0 && (
+                    <BadgeNumber>{handleNotifCount(unread)}</BadgeNumber>
+                  )}
+                </>
+              )
+          )}
+        </FriendContainer>
         {/* <UserMenu username={username} setUsername={setUsername} /> */}
       </ConditionalNav>
     </>

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -150,12 +150,9 @@ const Inbox = styled.h1`
 `
 const HeaderDiv = styled.div`
   display: flex;
-  // position: relative;
   margin-left: -125%;
   margin-top: -125%; 
   width: 500%;
-  // border: outset 1px dimgrey;
-  border-bottom: groove 1px dimgrey;
   background-color: DimGrey;
   padding-top: 0vh;
   padding 5em;
@@ -167,21 +164,17 @@ const HeaderDiv = styled.div`
 `
 
 const FriendContainer = styled.div`
-  // margin-top: 4em;
   display: flex;
   flex-direction: column;
   width: 500%;
-  // position: fixed;
   // background: #696969;
+  background-opacity: 20%;
   padding: 4em;
   max-width: 10em;
   padding-bottom: 4.4em;
-  // max-width: 4em;
   padding-right: 0;
   margin-left: -125%;
-  // padding-right: 0;
   border-radius: 5px;
-  // border-top: groove 1px dimgrey;
 `
 function handleProps(props) {
   return props.open === true ? `flex` : `none`

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -1,17 +1,14 @@
-import React, { useContext, useRef, useState } from 'react'
+import React, { useContext, useRef } from 'react'
 import styled from 'styled-components'
 import { ChatContext } from '../context/ChatContext'
 import { FriendContext } from '../context/FriendContext'
 import { device } from '../worker/breakpoints'
 import { Friends } from '../worker/FakeData'
-import { TbMessageCircle2, TbDoorExit } from 'react-icons/tb'
 import { FaTimes } from 'react-icons/fa'
 import { Link } from 'react-router-dom'
 import UserMenu from './UserMenu'
 import FriendModal from './FriendModal'
-// import { Close } from '@styled-icons/zondicons'
-import { Close } from '@styled-icons/material-rounded'
-// @styled-icons/zondicons/Close
+
 const ConditionalNav = styled.section`
   margin: 0;
   border: solid 3px #505050;
@@ -21,7 +18,6 @@ const ConditionalNav = styled.section`
   right: 7vw;
   top: 32vh;
   height: 30vh;
-  // width: 500%;
   padding: 5em;
   border-radius: 8px;
   flex-grow: 1;
@@ -54,41 +50,39 @@ const ConditionalNav = styled.section`
   }
 `
 
-const NavbarLink = styled(Link)`
-  color: #ffffff;
-  display: flex;
-  position: relative;
-  // position: absolute;
-  // left: 1%;
-  left: 1%;
-  font-style: normal;
-  font-weight: 700;
-  margin-left: 0.5em;
-  text-decoration: none;
-  margin-top: 0.5em;
-  margin-bottom: auto;
-  &:hover {
-    text-shadow: #ffffff 0.5px 0 2.5px;
-  }
-  @media only screen and ${device.xs} {
-    font-size: x-small;
-  }
-  @media only screen and ${device.sm} {
-    font-size: small;
-  }
-  @media only screen and ${device.md} {
-    margin-left: 1.2em;
-    font-size: medium;
-  }
-  @media only screen and ${device.lg} {
-    margin-left: 1.2em;
-    font-sze: medium;
-  }
-  @media only screen and ${device.xlg} {
-    font-size: large;
-    margin-left: 2em;
-  }
-`
+// const NavbarLink = styled(Link)`
+//   color: #ffffff;
+//   display: flex;
+//   position: relative;
+//   left: 1%;
+//   font-style: normal;
+//   font-weight: 700;
+//   margin-left: 0.5em;
+//   text-decoration: none;
+//   margin-top: 0.5em;
+//   margin-bottom: auto;
+//   &:hover {
+//     text-shadow: #ffffff 0.5px 0 2.5px;
+//   }
+//   @media only screen and ${device.xs} {
+//     font-size: x-small;
+//   }
+//   @media only screen and ${device.sm} {
+//     font-size: small;
+//   }
+//   @media only screen and ${device.md} {
+//     margin-left: 1.2em;
+//     font-size: medium;
+//   }
+//   @media only screen and ${device.lg} {
+//     margin-left: 1.2em;
+//     font-sze: medium;
+//   }
+//   @media only screen and ${device.xlg} {
+//     font-size: large;
+//     margin-left: 2em;
+//   }
+// `
 
 const User = styled.h1`
   position: relative;
@@ -112,58 +106,10 @@ const Messages = styled.p`
   display: flex;
   color: #ffffff;
   position: relative;
-  top: -1vh;
-  margin-left: 1em;
-  font-size: 100%;
+  top: -4.9vh;
+  // margin-left: 1em;
+  font-size: small;
   margin-right: 1em;
-`
-
-const Badge = styled(TbMessageCircle2)`
-  display: flex;
-  color: #ffffff;
-  margin-top: -1.5em;
-  font-size: 1rem;
-  transform: rotateZ(90deg) rotate(0.5turn);
-  @media only screen and ${device.xs} {
-  }
-  @media only screen and ${device.sm} {
-  }
-  @media only screen and ${device.md} {
-    margin-left: 0.1em;
-  }
-  @media only screen and ${device.lg} {
-    margin-left: 0.1em;
-  }
-  @media only screen and ${device.xlg} {
-    font-size: 1rem;
-    margin-left: 1em;
-  }
-`
-
-const BadgeNumber = styled.p`
-  dislay: flex;
-  margin-left: 2.2em;
-  margin-top: -1.6em;
-  font-size: 0.6em;
-  width: 25%;
-  color: #ffffff;
-  text-shadow: #ffffff 0.5px 0 2.5px;
-  @media only screen and ${device.xs} {
-  }
-  @media only screen and ${device.sm} {
-  }
-  @media only screen and ${device.md} {
-    margin-left: 0.8em;
-    font-sze: 2em;
-  }
-  @media only screen and ${device.lg} {
-    margin-left: 0.8em;
-    font-sze: 2em;
-  }
-  @media only screen and ${device.xlg} {
-    margin-left: 2.2em;
-    font-size: 0.6em;
-  }
 `
 
 const Inbox = styled.h1`
@@ -181,7 +127,6 @@ const Inbox = styled.h1`
   margin-top: 0;
   margin-bottom: 0;
   color: #ffffff;
-  // cursor: context-menu;
 `
 const CloseInbox = styled(FaTimes)`
   display: flex;
@@ -189,11 +134,8 @@ const CloseInbox = styled(FaTimes)`
   top: 30%;
   right: 10%;
   font-size: 2.5vw;
-  // color: #ffffff;
   cursor: pointer;
   color: #ffffff;
-  // background-color: #ffffff;
-
 `
 
 const HeaderDiv = styled.div`
@@ -236,7 +178,7 @@ const FriendCell = styled.div`
   border-bottom: solid 1px #696969;
   padding-left: 1em;
   margin: 0 auto;
-  max-height: 10vh;
+  max-height: 15vh;
 `
 
 const Avatar = styled.img`
@@ -254,26 +196,12 @@ const Avatar = styled.img`
 const Timestamp = styled.p`
   color: #ffffff;
   position: absolute;
+  font-style: italic;
   top: 6vh;
-  // border: 1px solid red;
-  // margin-left: 2.3em;
-  // margin-top: -3vh;
   font-size: small;
-  // &:hover {
-  //   cursor: context-menu;
-  // }
-  // @media only screen and ${device.xs} {
-  //   margin-left: 1.5em;
-  // }
-  // @media only screen and ${device.sm} {
-  //   margin-left: 1.5em;
-  // }
-  // @media only screen and ${device.md} {
-  //   margin-left: 2.3em;
-  // }
-  // @media only screen and ${device.lg} {
-  //   margin-left: 2.3em;
-  // }
+  left: 1.7vw;
+  text-transform: italics;
+  opacity: 80%;
 `
 function handleProps(props) {
   return props.open === true ? `flex` : `none`
@@ -350,6 +278,7 @@ const ConditionalNavBar = () => {
                       {name}
                     </User>
                     <Timestamp>{messages[0].timestamp}</Timestamp>
+                    <Messages>{messages[0].message}</Messages>
                   </FriendCell>
                 </>
               )

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -105,7 +105,7 @@ const Messages = styled.p`
   margin-right: 2em;
 `
 
-const Inbox = styled.h1`
+const Header = styled.h1`
   display: flex;
   position: absolute;
   margin-top: 1vh;
@@ -238,7 +238,8 @@ const ConditionalNavBar = () => {
 
   useEffect(() => {
     console.log(friendRefs)
-    innerWidth < dimensions ? setInboxView(false) : console.log('!')
+    // innerWidth < dimensions ? handleChatStateChange() : console.log('!')
+    // innerWidth > dimensions ? handleChatStateChange() : setInboxView(false)
   }, [friendRefs, innerWidth, dimensions])
 
   const handleClose = () => {
@@ -247,7 +248,8 @@ const ConditionalNavBar = () => {
   }
 
   const handleBackArrow = () => {
-    setInboxView(false)
+    setInboxView(!inboxView)
+    handleChatStateChange()
   }
 
   return (
@@ -255,7 +257,7 @@ const ConditionalNavBar = () => {
       {openMiniModal && <FriendModal nav={nav} />}
       <ConditionalNav open={openChat}>
         <HeaderDiv>
-          <Inbox>Inbox</Inbox>
+          {inboxView ? <Header>Inbox</Header> : <Header>Friends</Header>}
           <CloseInbox onClick={handleClose} />
           <BackArrow onClick={handleBackArrow} />
         </HeaderDiv>

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -1,13 +1,11 @@
-import React, { useContext, useRef } from 'react'
+import React, { useContext, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import { ChatContext } from '../context/ChatContext'
 import { FriendContext } from '../context/FriendContext'
 import { device } from '../worker/breakpoints'
 import { Friends } from '../worker/FakeData'
-import { FaTimes } from 'react-icons/fa'
 import { ImCross } from 'react-icons/im'
 import { Link } from 'react-router-dom'
-import UserMenu from './UserMenu'
 import FriendModal from './FriendModal'
 
 const ConditionalNav = styled.section`
@@ -29,25 +27,13 @@ const ConditionalNav = styled.section`
     display: flex;
     width: 4em;
     top: 37vh;
-    right: 4vw;
+    right: 3vw;
   }
   @media only screen and ${device.md} {
     display: ${(props) => handleProps(props)};
     width: 4em;
     top: 37vh;
-    right: 4vw;
-  }
-  @media only screen and ${device.lg} {
-    display: ${(props) => handleProps(props)};
-    width: 4em;
-    top: 37vh;
-    right: 5vw;
-  }
-  @media only screen and ${device.xlg} {
-    display: ${(props) => handleProps(props)};
-    width: 4em;
-    top: 37vh;
-    right: 5vw;
+    right: 3vw;
   }
 `
 
@@ -107,10 +93,11 @@ const Messages = styled.p`
   display: flex;
   color: #ffffff;
   position: relative;
-  top: -4.9vh;
-  // margin-left: 1em;
+  top: -5vh;
+  margin: 0;
+  padding: 0;
   font-size: small;
-  margin-right: 1em;
+  margin-right: 2em;
 `
 
 const Inbox = styled.h1`
@@ -134,19 +121,16 @@ const CloseInbox = styled(ImCross)`
   position: absolute;
   top: 33%;
   right: 5%;
-  font-size: 2vw;
+  font-size: 25px;
   cursor: pointer;
   color: #ffffff;
+  @media only screen and ${device.sm} {
+    display: none;
+  }
+  @media only screen and ${device.md} {
+    display: flex;
+  }
 `
-// const CloseInbox = styled(FaTimes)`
-//   display: flex;
-//   position: absolute;
-//   top: 30%;
-//   right: 10%;
-//   font-size: 2.5vw;
-//   cursor: pointer;
-//   color: #ffffff;
-// `
 
 const HeaderDiv = styled.div`
   display: flex;
@@ -169,8 +153,9 @@ const FriendContainer = styled.div`
   position: relative;
   flex-direction: column;
   margin: 0 auto;
-  max-height: 50vh;
-  max-width: 25vw;
+  max-height: 50em;
+  min-width: 14em;
+  width: 100%;
   margin-left: -125%;
   margin-bottom: -125%;
   border-radius: 5px;
@@ -179,13 +164,14 @@ const FriendContainer = styled.div`
 `
 
 const FriendCell = styled.div`
-  width: 16.4vw;
+  width: 100%;
   position: relative;
   padding-top: 1em;
   border-bottom: solid 1px #696969;
   padding-left: 1em;
   margin: 0 auto;
-  max-height: 15vh;
+  max-height: auto;
+  margin-bottom: 0;
 `
 
 const Avatar = styled.img`
@@ -202,11 +188,13 @@ const Avatar = styled.img`
 
 const Timestamp = styled.p`
   color: #ffffff;
-  position: absolute;
+  position: relative;
   font-style: italic;
-  top: 6vh;
-  font-size: small;
-  left: 1.7vw;
+  margin: 0;
+  padding: 0;
+  top: -5vh;
+  font-size: x-small;
+  left: 0.5vw;
   text-transform: italics;
   opacity: 80%;
 `
@@ -215,44 +203,14 @@ function handleProps(props) {
 }
 
 const ConditionalNavBar = () => {
-  const {
-    handleChatStateChange,
-    openChat,
-    openMiniModal,
-    setOpenMini,
-    setNav,
-    nav,
-  } = useContext(ChatContext)
-  // const {
-  //   setFriendName,
-  //   setAvatar,
-  //   setOffsetLeft,
-  //   setOffsetTop,
-  //   getUnread,
-  //   unreadMessages,
-  //   handleNotifCount,
-  // } = useContext(FriendContext)
-
-  // function handleMouseOver(id, name, avatar, i) {
-  //   setNav('conditional')
-  //   getUnread(id, Friends)
-  //   setOpenMini(true)
-  //   setFriendName(name)
-  //   setAvatar(avatar)
-  //   setOffsetLeft(friendRefs.current[i].offsetLeft)
-  //   setOffsetTop(friendRefs.current[i].offsetTop)
-  // }
-
-  // const handleMouseOut = () => {
-  //   setOpenMini(false)
-  //   setOpenMini(false)
-  //   setFriendName('')
-  //   setAvatar('')
-  //   setOffsetLeft(0)
-  //   setOffsetTop(0)
-  // }
+  const { handleChatStateChange, openChat, openMiniModal, nav } =
+    useContext(ChatContext)
 
   const friendRefs = useRef([])
+
+  useEffect(() => {
+    console.log(friendRefs)
+  }, [friendRefs])
 
   return (
     <>
@@ -272,15 +230,14 @@ const ConditionalNavBar = () => {
                     friendRefs.current[i] = ref
                   }}
                   key={id}
-                  // onClick={handleChatStateChange}
+                  onClick={() => {}}
                 >
                   <Avatar src={avatar} />
-                  <User
-                  >
-                    {name}
-                  </User>
-                  <Timestamp>{messages[0].timestamp}</Timestamp>
-                  <Messages>{messages[0].message}</Messages>
+                  <User>{name}</User>
+                  <Timestamp>
+                    {messages[messages.length - 1].timestamp}
+                  </Timestamp>
+                  <Messages>{messages[messages.length - 1].message}</Messages>
                 </FriendCell>
               )
           )}

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -181,9 +181,7 @@ const FriendContainer = styled.div`
 const FriendCell = styled.div`
   width: 16.4vw;
   position: relative;
-  // left: -5vw;
   padding-top: 1em;
-  // top: -1vh;
   border-bottom: solid 1px #696969;
   padding-left: 1em;
   margin: 0 auto;
@@ -225,34 +223,34 @@ const ConditionalNavBar = () => {
     setNav,
     nav,
   } = useContext(ChatContext)
-  const {
-    setFriendName,
-    setAvatar,
-    setOffsetLeft,
-    setOffsetTop,
-    getUnread,
-    unreadMessages,
-    handleNotifCount,
-  } = useContext(FriendContext)
+  // const {
+  //   setFriendName,
+  //   setAvatar,
+  //   setOffsetLeft,
+  //   setOffsetTop,
+  //   getUnread,
+  //   unreadMessages,
+  //   handleNotifCount,
+  // } = useContext(FriendContext)
 
-  function handleMouseOver(id, name, avatar, i) {
-    setNav('conditional')
-    getUnread(id, Friends)
-    setOpenMini(true)
-    setFriendName(name)
-    setAvatar(avatar)
-    setOffsetLeft(friendRefs.current[i].offsetLeft)
-    setOffsetTop(friendRefs.current[i].offsetTop)
-  }
+  // function handleMouseOver(id, name, avatar, i) {
+  //   setNav('conditional')
+  //   getUnread(id, Friends)
+  //   setOpenMini(true)
+  //   setFriendName(name)
+  //   setAvatar(avatar)
+  //   setOffsetLeft(friendRefs.current[i].offsetLeft)
+  //   setOffsetTop(friendRefs.current[i].offsetTop)
+  // }
 
-  const handleMouseOut = () => {
-    setOpenMini(false)
-    setOpenMini(false)
-    setFriendName('')
-    setAvatar('')
-    setOffsetLeft(0)
-    setOffsetTop(0)
-  }
+  // const handleMouseOut = () => {
+  //   setOpenMini(false)
+  //   setOpenMini(false)
+  //   setFriendName('')
+  //   setAvatar('')
+  //   setOffsetLeft(0)
+  //   setOffsetTop(0)
+  // }
 
   const friendRefs = useRef([])
 

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -5,6 +5,7 @@ import { FriendContext } from '../context/FriendContext'
 import { device } from '../worker/breakpoints'
 import { Friends } from '../worker/FakeData'
 import { FaTimes } from 'react-icons/fa'
+import { ImCross } from 'react-icons/im'
 import { Link } from 'react-router-dom'
 import UserMenu from './UserMenu'
 import FriendModal from './FriendModal'
@@ -128,15 +129,24 @@ const Inbox = styled.h1`
   margin-bottom: 0;
   color: #ffffff;
 `
-const CloseInbox = styled(FaTimes)`
+const CloseInbox = styled(ImCross)`
   display: flex;
   position: absolute;
-  top: 30%;
-  right: 10%;
-  font-size: 2.5vw;
+  top: 33%;
+  right: 5%;
+  font-size: 2vw;
   cursor: pointer;
   color: #ffffff;
 `
+// const CloseInbox = styled(FaTimes)`
+//   display: flex;
+//   position: absolute;
+//   top: 30%;
+//   right: 10%;
+//   font-size: 2.5vw;
+//   cursor: pointer;
+//   color: #ffffff;
+// `
 
 const HeaderDiv = styled.div`
   display: flex;
@@ -156,12 +166,11 @@ const HeaderDiv = styled.div`
 
 const FriendContainer = styled.div`
   display: flex;
+  position: relative;
   flex-direction: column;
   margin: 0 auto;
-  background-opacity: 20%;
-  max-height: 23vh;
-  padding: 4em;
-  max-width: 6em;
+  max-height: 50vh;
+  max-width: 25vw;
   margin-left: -125%;
   margin-bottom: -125%;
   border-radius: 5px;
@@ -172,9 +181,9 @@ const FriendContainer = styled.div`
 const FriendCell = styled.div`
   width: 16.4vw;
   position: relative;
-  left: -5vw;
+  // left: -5vw;
   padding-top: 1em;
-  top: -10vh;
+  // top: -1vh;
   border-bottom: solid 1px #696969;
   padding-left: 1em;
   margin: 0 auto;
@@ -260,27 +269,21 @@ const ConditionalNavBar = () => {
             ({ name, id, avatar, unread, messages, online, timestamp }, i) =>
               online === '1' &&
               unread > 0 && (
-                <>
-                  <FriendCell
-                    ref={(ref) => {
-                      friendRefs.current[i] = ref
-                    }}
-                    key={id}
-                    // onClick={handleChatStateChange}
+                <FriendCell
+                  ref={(ref) => {
+                    friendRefs.current[i] = ref
+                  }}
+                  key={id}
+                  // onClick={handleChatStateChange}
+                >
+                  <Avatar src={avatar} />
+                  <User
                   >
-                    <Avatar src={avatar} />
-                    <User
-
-                    // onMouseOver={() => handleMouseOver(id, name, avatar, i)}
-                    // onMouseOut={handleMouseOut}
-                    // onClick={handleChatStateChange}
-                    >
-                      {name}
-                    </User>
-                    <Timestamp>{messages[0].timestamp}</Timestamp>
-                    <Messages>{messages[0].message}</Messages>
-                  </FriendCell>
-                </>
+                    {name}
+                  </User>
+                  <Timestamp>{messages[0].timestamp}</Timestamp>
+                  <Messages>{messages[0].message}</Messages>
+                </FriendCell>
               )
           )}
         </FriendContainer>

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -223,8 +223,6 @@ const Timestamp = styled.p`
 `
 
 const ConditionalNavBar = () => {
-  const [dimensions, setDimensions] = useState(+device.md.slice(0, 3))
-  const [innerWidth, setInnerWidth] = useState(Window.innerWidth)
   const {
     handleChatStateChange,
     openChat,
@@ -238,9 +236,7 @@ const ConditionalNavBar = () => {
 
   useEffect(() => {
     console.log(friendRefs)
-    // innerWidth < dimensions ? handleChatStateChange() : console.log('!')
-    // innerWidth > dimensions ? handleChatStateChange() : setInboxView(false)
-  }, [friendRefs, innerWidth, dimensions])
+  }, [friendRefs])
 
   const handleClose = () => {
     setInboxView(false)
@@ -264,7 +260,7 @@ const ConditionalNavBar = () => {
         <FriendContainer>
           {inboxView &&
             Friends.map(
-              ({ name, id, avatar, unread, messages, online, timestamp }, i) =>
+              ({ name, id, avatar, unread, messages, online }, i) =>
                 online === '1' &&
                 unread > 0 && (
                   <FriendCell

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -223,6 +223,8 @@ const Timestamp = styled.p`
 `
 
 const ConditionalNavBar = () => {
+  const [dimensions, setDimensions] = useState(+device.md.slice(0, 3))
+  const [innerWidth, setInnerWidth] = useState(Window.innerWidth)
   const {
     handleChatStateChange,
     openChat,
@@ -236,7 +238,8 @@ const ConditionalNavBar = () => {
 
   useEffect(() => {
     console.log(friendRefs)
-  }, [friendRefs])
+    innerWidth < dimensions ? setInboxView(false) : console.log('!')
+  }, [friendRefs, innerWidth, dimensions])
 
   const handleClose = () => {
     setInboxView(false)
@@ -257,7 +260,7 @@ const ConditionalNavBar = () => {
           <BackArrow onClick={handleBackArrow} />
         </HeaderDiv>
         <FriendContainer>
-          {inboxView ? (
+          {inboxView &&
             Friends.map(
               ({ name, id, avatar, unread, messages, online, timestamp }, i) =>
                 online === '1' &&
@@ -277,9 +280,8 @@ const ConditionalNavBar = () => {
                     <Messages>{messages[messages.length - 1].message}</Messages>
                   </FriendCell>
                 )
-            )
-          ) : (
-            //null
+            )}
+          {!inboxView && (
             <NavMapper friends={Friends} friendRefs={friendRefs} />
           )}
         </FriendContainer>

--- a/src/components/ConditionalNavBar.js
+++ b/src/components/ConditionalNavBar.js
@@ -1,12 +1,14 @@
-import React, { useContext, useEffect, useRef } from 'react'
+import React, { useContext, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { ChatContext } from '../context/ChatContext'
 import { FriendContext } from '../context/FriendContext'
 import { device } from '../worker/breakpoints'
 import { Friends } from '../worker/FakeData'
 import { ImCross } from 'react-icons/im'
+import { FaArrowLeft } from 'react-icons/fa'
 import { Link } from 'react-router-dom'
 import FriendModal from './FriendModal'
+import NavMapper from './NavMapper'
 
 const ConditionalNav = styled.section`
   margin: 0;
@@ -37,6 +39,9 @@ const ConditionalNav = styled.section`
   }
 `
 
+function handleProps(props) {
+  return props.open === true ? `flex` : `none`
+}
 // const NavbarLink = styled(Link)`
 //   color: #ffffff;
 //   display: flex;
@@ -116,6 +121,21 @@ const Inbox = styled.h1`
   margin-bottom: 0;
   color: #ffffff;
 `
+const BackArrow = styled(FaArrowLeft)`
+  display: flex;
+  position: absolute;
+  top: 33%;
+  right: 5%;
+  font-size: 25px;
+  cursor: pointer;
+  color: #ffffff;
+  @media only screen and ${device.sm} {
+    display: flex;
+  }
+  @media only screen and ${device.md} {
+    display: none;
+  }
+`
 const CloseInbox = styled(ImCross)`
   display: flex;
   position: absolute;
@@ -128,6 +148,9 @@ const CloseInbox = styled(ImCross)`
     display: none;
   }
   @media only screen and ${device.md} {
+    display: flex;
+  }
+  @media only screen and ${device.lg} {
     display: flex;
   }
 `
@@ -198,13 +221,16 @@ const Timestamp = styled.p`
   text-transform: italics;
   opacity: 80%;
 `
-function handleProps(props) {
-  return props.open === true ? `flex` : `none`
-}
 
 const ConditionalNavBar = () => {
-  const { handleChatStateChange, openChat, openMiniModal, nav } =
-    useContext(ChatContext)
+  const {
+    handleChatStateChange,
+    openChat,
+    openMiniModal,
+    nav,
+    inboxView,
+    setInboxView,
+  } = useContext(ChatContext)
 
   const friendRefs = useRef([])
 
@@ -212,34 +238,49 @@ const ConditionalNavBar = () => {
     console.log(friendRefs)
   }, [friendRefs])
 
+  const handleClose = () => {
+    setInboxView(false)
+    handleChatStateChange()
+  }
+
+  const handleBackArrow = () => {
+    setInboxView(false)
+  }
+
   return (
     <>
       {openMiniModal && <FriendModal nav={nav} />}
       <ConditionalNav open={openChat}>
         <HeaderDiv>
           <Inbox>Inbox</Inbox>
-          <CloseInbox onClick={handleChatStateChange} />
+          <CloseInbox onClick={handleClose} />
+          <BackArrow onClick={handleBackArrow} />
         </HeaderDiv>
         <FriendContainer>
-          {Friends.map(
-            ({ name, id, avatar, unread, messages, online, timestamp }, i) =>
-              online === '1' &&
-              unread > 0 && (
-                <FriendCell
-                  ref={(ref) => {
-                    friendRefs.current[i] = ref
-                  }}
-                  key={id}
-                  onClick={() => {}}
-                >
-                  <Avatar src={avatar} />
-                  <User>{name}</User>
-                  <Timestamp>
-                    {messages[messages.length - 1].timestamp}
-                  </Timestamp>
-                  <Messages>{messages[messages.length - 1].message}</Messages>
-                </FriendCell>
-              )
+          {inboxView ? (
+            Friends.map(
+              ({ name, id, avatar, unread, messages, online, timestamp }, i) =>
+                online === '1' &&
+                unread > 0 && (
+                  <FriendCell
+                    ref={(ref) => {
+                      friendRefs.current[i] = ref
+                    }}
+                    key={id}
+                    onClick={() => {}}
+                  >
+                    <Avatar src={avatar} />
+                    <User>{name}</User>
+                    <Timestamp>
+                      {messages[messages.length - 1].timestamp}
+                    </Timestamp>
+                    <Messages>{messages[messages.length - 1].message}</Messages>
+                  </FriendCell>
+                )
+            )
+          ) : (
+            //null
+            <NavMapper friends={Friends} friendRefs={friendRefs} />
           )}
         </FriendContainer>
         {/* <UserMenu username={username} setUsername={setUsername} /> */}

--- a/src/components/DashLayoutComponent.js
+++ b/src/components/DashLayoutComponent.js
@@ -16,7 +16,7 @@ const Wrapper = styled.div`
 const Chatr = styled.p`
   display: flex;
   color: #1a8cff;
-  width: 10vw;
+  width: 12vw;
   border-bottom: solid 1px DimGrey;
   font-style: normal;
   font-weight: 700;

--- a/src/components/DashLayoutComponent.js
+++ b/src/components/DashLayoutComponent.js
@@ -1,8 +1,10 @@
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
 import SideNav from './SideNav'
 import styled from 'styled-components'
 import FriendModal from './FriendModal'
 import { device } from '../worker/breakpoints'
+import { ChatContext } from '../context/ChatContext'
+
 const Wrapper = styled.div`
   width: 100%;
   background-color: #474747;
@@ -26,31 +28,32 @@ const Chatr = styled.p`
   }
   position: fixed;
   border-radius: 2px;
-  @media only screen and ${device.xs}{
+  @media only screen and ${device.xs} {
     display: none;
   }
-  @media only screen and ${device.sm}{
+  @media only screen and ${device.sm} {
     display: none;
   }
-  @media only screen and ${device.md}{
+  @media only screen and ${device.md} {
     display: flex;
   }
-  @media only screen and ${device.lg}{
+  @media only screen and ${device.lg} {
     display: flex;
   }
-  @media only screen and ${device.xlg}{
+  @media only screen and ${device.xlg} {
     display: flex;
   }
 `
 
 const DashLayoutComponent = ({ children }) => {
-  const [open, setOpen] = useState(false)
+  const { openMiniModal, setOpenMini } = useContext(ChatContext)
+  const { nav } = useContext(ChatContext)
   return (
     <>
       <Wrapper>
-        <SideNav open={open} setOpen={setOpen} />
+        <SideNav open={openMiniModal} setOpen={setOpenMini} />
         <Chatr>chatr</Chatr>
-        {open && <FriendModal />}
+        {openMiniModal && <FriendModal nav={nav} />}
         {children}
       </Wrapper>
     </>

--- a/src/components/FriendModal.js
+++ b/src/components/FriendModal.js
@@ -19,6 +19,7 @@ function handleOffsetTopProps(props) {
     return (props) => props.top + 65
   }
 }
+
 function handleMarginLeftProps(props) {
   if (props.nav === 'conditional') {
     return (props) => props.left + 350

--- a/src/components/FriendModal.js
+++ b/src/components/FriendModal.js
@@ -30,40 +30,57 @@ function handleMarginLeftProps(props) {
 }
 
 const Modal = styled.div`
-  display: grid;
   position: fixed;
   left: ${handleOffsetLeftProps}px;
   top: ${handleOffsetTopProps}px;
-  flex-direction: row;
+  flex-direction: column;
   flex-grow: 1;
   backdrop-filter: grayscale(100%);
-  padding: 2em;
-  margin: auto;
+  padding: 3vw;
   margin-left: ${handleMarginLeftProps}px;
-  min-height: 2em;
+  min-height: 1em;
   max-height: 5em;
   height: auto;
-  max-width: 3em;
-  text-overflow: ellipsis;
+  width: auto;
+  max-width: 5em;
   background-color: #909090;
   border-radius: 5px;
   border: solid 1px #505050;
-  text-overflow: ellipsis;
+  // text-overflow: ellipsis;
   overflow: hidden;
 `
 const Username = styled.p`
   color: #ffffff;
   position: absolute;
-  top: 10%;
-  left: 40%;
+  top: 8%;
+  left: 30%;
   padding: 0;
   margin: 0;
-  font-size: large;
+  font-size: x-large;
 `
-
-const Messages = styled.p`
+const BioTray = styled.div`
+  position: relative;
+  padding: auto;
+  flex-grow: 1;
+  // left: -2vw;
+  min-width: 5vw;
+  max-width: 25vw;
+  padding-right: 2vw;
+  // padding-left; 2vw;
+  width: 5vw;
+  margin-left: -2vw;
+  border: solid 1px #ffffff;
+  border-radius: 6px;
+  overflowX: hidden;
+`
+const Bio = styled.p`
   color: #ffffff;
-  font-size: x-small;
+  font-size: small;
+  display: flex;
+  position: relative;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 `
 
 const Avatar = styled.img`
@@ -75,6 +92,17 @@ const Avatar = styled.img`
   height: 2em;
   padding-bottom: 0;
 `
+
+const UnreadAvatar = styled.img`
+  border-radius: 50%;
+  position: fixed;
+  top: 5%;
+  left: 4%;
+  width: 2em;
+  height: 2em;
+  padding-bottom: 0;
+  border: 2px solid #1a8cff;
+`
 export default function FriendModal({ nav }) {
   const [defaultMessage, setDefault] = useState(
     "That's alot of messages! Might want to reach out..."
@@ -83,15 +111,27 @@ export default function FriendModal({ nav }) {
     useContext(FriendContext)
   return (
     <Modal draggable left={offsetLeft} top={offsetTop} nav={nav}>
-      <Avatar
-        src={
-          avatar?.length
-            ? avatar
-            : 'https://static.tvtropes.org/pmwiki/pub/images/abcb6534_7913_4eb1_a7a5_62b081ebc628.png'
-        }
-      />
+      {unreadMessages.length > 0 ? (
+        <UnreadAvatar
+          src={
+            avatar?.length
+              ? avatar
+              : 'https://static.tvtropes.org/pmwiki/pub/images/abcb6534_7913_4eb1_a7a5_62b081ebc628.png'
+          }
+        />
+      ) : (
+        <Avatar
+          src={
+            avatar?.length
+              ? avatar
+              : 'https://static.tvtropes.org/pmwiki/pub/images/abcb6534_7913_4eb1_a7a5_62b081ebc628.png'
+          }
+        />
+      )}
       <Username>{friendName}</Username>
-      <Messages>{bio}</Messages>
+      {/* <BioTray> */}
+        <Bio>{bio}</Bio>
+      {/* </BioTray> */}
     </Modal>
   )
 }

--- a/src/components/FriendModal.js
+++ b/src/components/FriendModal.js
@@ -2,17 +2,43 @@ import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 import { FriendContext } from '../context/FriendContext'
 
+function handleOffsetLeftProps(props) {
+  if (props.nav === 'conditional') {
+    return (props) => props.left + 350
+  }
+  if (props.nav === 'side') {
+    return (props) => props.left + 10
+  }
+}
+
+function handleOffsetTopProps(props) {
+  if (props.nav === 'conditional') {
+    return (props) => props.top + 300
+  }
+  if (props.nav === 'side') {
+    return (props) => props.top + 65
+  }
+}
+function handleMarginLeftProps(props) {
+  if (props.nav === 'conditional') {
+    return (props) => props.left + 350
+  }
+  if (props.nav === 'side') {
+    return (props) => props.left + 15
+  }
+}
+
 const Modal = styled.div`
   display: grid;
   position: fixed;
-  left: ${(props) => props.left + 10}px;
-  top: ${(props) => props.top + 65}px;
+  left: ${handleOffsetLeftProps}px;
+  top: ${handleOffsetTopProps}px;
   flex-direction: row;
   flex-grow: 1;
   backdrop-filter: grayscale(100%);
   padding: 2em;
   margin: auto;
-  margin-left: ${(props) => props.left + 15}px;
+  margin-left: ${handleMarginLeftProps}px;
   min-height: 2em;
   max-height: 5em;
   height: auto;
@@ -48,14 +74,14 @@ const Avatar = styled.img`
   height: 2em;
   padding-bottom: 0;
 `
-export default function FriendModal() {
+export default function FriendModal({ nav }) {
   const [defaultMessage, setDefault] = useState(
     "That's alot of messages! Might want to reach out..."
   )
   const { friendName, avatar, unreadMessages, offsetLeft, offsetTop } =
     useContext(FriendContext)
   return (
-    <Modal draggable left={offsetLeft} top={offsetTop}>
+    <Modal draggable left={offsetLeft} top={offsetTop} nav={nav}>
       <Avatar
         src={
           avatar?.length

--- a/src/components/FriendModal.js
+++ b/src/components/FriendModal.js
@@ -79,7 +79,7 @@ export default function FriendModal({ nav }) {
   const [defaultMessage, setDefault] = useState(
     "That's alot of messages! Might want to reach out..."
   )
-  const { friendName, avatar, unreadMessages, offsetLeft, offsetTop } =
+  const { friendName, avatar, unreadMessages, bio, offsetLeft, offsetTop } =
     useContext(FriendContext)
   return (
     <Modal draggable left={offsetLeft} top={offsetTop} nav={nav}>
@@ -91,11 +91,7 @@ export default function FriendModal({ nav }) {
         }
       />
       <Username>{friendName}</Username>
-      {unreadMessages.length < 10 ? (
-        <Messages>{unreadMessages[unreadMessages.length - 1]}</Messages>
-      ) : (
-        <Messages>{defaultMessage}</Messages>
-      )}
+      <Messages>{bio}</Messages>
     </Modal>
   )
 }

--- a/src/components/MainFeed.js
+++ b/src/components/MainFeed.js
@@ -9,9 +9,11 @@ const User = styled.h1`
   font-weight: 600;
   font-size: 200%;
   margin-left: 2.1em;
-  display: flex;
+  display: block;
   top: -2.5%;
-  margin-top: 0;
+  margin-top: -5vh;
+  // margin-top: 0;
+  padding-top: 0;
   padding: 0;
   right: 0;
   color: #ffffff;
@@ -23,24 +25,29 @@ const User = styled.h1`
 
 const Avatar = styled.img`
   display: block;
+  // margin-top: -5vh;
   border-radius: 50%;
   position: relative;
   left: 1.3em;
-  top: 2em;
+  top: .7em;
   width: 2em;
   height: 2em;
   margin-top: 0;
+  padding-top: 0;
 `
 const UnreadAvatar = styled.img`
-  display: block;
-  border-radius: 50%;
-  position: relative;
-  left: 1.3em;
-  top: 2em;
-  width: 2em;
-  height: 2em;
-  margin-top: 0;
+display: block;
+// margin-top: -5vh;
+border-radius: 50%;
+position: relative;
+left: 1.3em;
+top: .7em;
+width: 2em;
+height: 2em;
+margin-top: 0;
+padding-top: 0;
   border: 2px solid #1a8cff;
+  // padding-top: 0;
 `
 
 const Messages = styled.p`
@@ -85,9 +92,12 @@ const Wrapper = styled.div`
 const FriendCell = styled.div`
   border: solid 3px #505050;
   background: DimGrey;
-  min-height: 7em;
+  // min-height: 6em;
+  height: auto;
   top: 3%;
   border-radius: 8px;
+  margin-top: 1vh;
+  padding-top: 0;
   @media only screen and ${device.xs} {
     max-width: 80vw;
     width: 80vw;
@@ -136,8 +146,10 @@ const MainFeed = () => {
                 <Avatar src={avatar} />
               )}
               <User>{name}</User>
-              <Timestamp>Today {messages[messages.length -1].timestamp}</Timestamp>
-              <Messages>{messages[messages.length -1].message}</Messages>
+              <Timestamp>
+                Today {messages[messages.length - 1].timestamp}
+              </Timestamp>
+              <Messages>{messages[messages.length - 1].message}</Messages>
             </FriendCell>
           </>
         ))}

--- a/src/components/MainFeed.js
+++ b/src/components/MainFeed.js
@@ -103,14 +103,14 @@ const FriendCell = styled.div`
   }
   @media only screen and ${device.md} {
     font-size: x-large;
-    width: 50vw;
+    width: 48vw;
     margin-left: 4vw;
     max-width: 50vw;
     margin-right: none;
   }
   @media only screen and ${device.lg} {
     font-size: x-large;
-    width: 50vw;
+    width: 49vw;
     margin-left: 4vw;
     max-width: 50vw;
     margin-right: none;
@@ -136,8 +136,8 @@ const MainFeed = () => {
                 <Avatar src={avatar} />
               )}
               <User>{name}</User>
-              <Timestamp>Yesterday {messages[0].timestamp}</Timestamp>
-              <Messages>{messages[0].message}</Messages>
+              <Timestamp>Today {messages[messages.length -1].timestamp}</Timestamp>
+              <Messages>{messages[messages.length -1].message}</Messages>
             </FriendCell>
           </>
         ))}

--- a/src/components/MainFeed.js
+++ b/src/components/MainFeed.js
@@ -10,10 +10,8 @@ const User = styled.h1`
   font-size: 200%;
   margin-left: 2.1em;
   display: block;
-  top: -2.5%;
-  margin-top: -5vh;
-  // margin-top: 0;
-  padding-top: 0;
+  margin-top: -4vh;
+  // padding-top: 0;
   padding: 0;
   right: 0;
   color: #ffffff;
@@ -21,6 +19,15 @@ const User = styled.h1`
     cursor: pointer;
   }
   font-size: 180%;
+  @media only screen and ${device.xs} {
+    margin-top: -3vh;
+  }
+  @media only screen and ${device.sm} {
+    margin-top: -3vh;
+  }
+  @media only screen and ${device.md} {
+    margin-top: -4vh;
+  }
 `
 
 const Avatar = styled.img`
@@ -29,7 +36,7 @@ const Avatar = styled.img`
   border-radius: 50%;
   position: relative;
   left: 1.3em;
-  top: .7em;
+  top: 1em;
   width: 2em;
   height: 2em;
   margin-top: 0;
@@ -41,7 +48,7 @@ display: block;
 border-radius: 50%;
 position: relative;
 left: 1.3em;
-top: .7em;
+top: 1em;
 width: 2em;
 height: 2em;
 margin-top: 0;
@@ -96,11 +103,11 @@ const FriendCell = styled.div`
   height: auto;
   top: 3%;
   border-radius: 8px;
-  margin-top: 1vh;
+  // margin-top: .2vh;
   padding-top: 0;
   @media only screen and ${device.xs} {
-    max-width: 80vw;
-    width: 80vw;
+    max-width: 100vw;
+    width: 85%;
     margin-left: auto;
     margin-right: auto;
   }

--- a/src/components/MainFeed.js
+++ b/src/components/MainFeed.js
@@ -73,9 +73,7 @@ const Timestamp = styled.p`
   margin-left: 2.3em;
   margin-top: -3vh;
   font-size: small;
-  &:hover {
-    cursor: context-menu;
-  }
+  font-style: italic;
   @media only screen and ${device.xs} {
     margin-left: 1.5em;
   }

--- a/src/components/MainFeed.js
+++ b/src/components/MainFeed.js
@@ -143,7 +143,7 @@ const MainFeed = () => {
   return (
     <>
       <Wrapper>
-        {Friends.map(({ avatar, name, messages, unread }) => (
+        {Friends.map(({ avatar, name, messages, unread, timestamp }) => (
           <>
             <FriendCell>
               {unread > 0 ? (
@@ -152,7 +152,7 @@ const MainFeed = () => {
                 <Avatar src={avatar} />
               )}
               <User>{name}</User>
-              <Timestamp>Today 5:12pm</Timestamp>
+              <Timestamp>Yesterday {messages[0].timestamp}</Timestamp>
               <Messages>{messages[0].message}</Messages>
             </FriendCell>
           </>

--- a/src/components/MainFeed.js
+++ b/src/components/MainFeed.js
@@ -74,6 +74,7 @@ const Timestamp = styled.p`
   margin-top: -3vh;
   font-size: small;
   font-style: italic;
+  opacity: 80%;
   @media only screen and ${device.xs} {
     margin-left: 1.5em;
   }

--- a/src/components/MainFeed.js
+++ b/src/components/MainFeed.js
@@ -16,7 +16,7 @@ const User = styled.h1`
   right: 0;
   color: #ffffff;
   &:hover {
-    cursor: context-menu;
+    cursor: pointer;
   }
   font-size: 180%;
 `
@@ -50,22 +50,7 @@ const Messages = styled.p`
   top: -1vh;
   margin-left: 1em;
   font-size: 100%;
-  &:hover {
-    cursor: context-menu;
-  }
   margin-right: 1em;
-  @media only screen and ${device.xs} {
-    font-size: 100%;
-  }
-  @media only screen and ${device.sm} {
-    font-size: 100%;
-  }
-  @media only screen and ${device.md} {
-    font-size: 100%;
-  }
-  @media only screen and ${device.lg} {
-    font-size: 100%;
-  }
 `
 const Timestamp = styled.p`
   color: #ffffff;

--- a/src/components/NameTag.js
+++ b/src/components/NameTag.js
@@ -41,6 +41,7 @@ const User = styled.h1`
   right: 15px;
 `
 const Nametag = styled.div`
+display: flex;
   border: solid 3px #505050;
   background: #696969;
   position: fixed;
@@ -58,35 +59,40 @@ const Nametag = styled.div`
     height: 4em;
     padding: 5em;
     padding-bottom: 0;
-    right: 4vw;
+    right: 3vw;
     display: flex;
   }
-  @media only screen and ${device.md} {
-    width: 4em;
-    height: 4em;
-    padding: 5em;
-    padding-bottom: 0;
-    right: 4vw;
-    display: flex;
-  }
-  @media only screen and ${device.lg} {
-    width: 4em;
-    height: 4em;
-    padding: 5em;
-    padding-bottom: 0;
-    right: 5vw;
-    display: flex;
-  }
-  @media only screen and ${device.xlg} {
-    width: 4em;
-    height: 4em;
-    padding: 5em;
-    padding-bottom: 0;
-    right: 5vw;
-    display: flex;
-  }
+  // @media only screen and ${device.md} {
+  //   width: 4em;
+  //   height: 4em;
+  //   padding: 5em;
+  //   padding-bottom: 0;
+  //   right: 5vw;
+  //   display: flex;
+  // }
+  // @media only screen and ${device.lg} {
+  //   width: 4em;
+  //   height: 4em;
+  //   padding: 5em;
+  //   padding-bottom: 0;
+  //   right: 5vw;
+  //   display: flex;
+  // }
+  // @media only screen and ${device.xlg} {
+  //   width: 4em;
+  //   height: 4em;
+  //   padding: 5em;
+  //   padding-bottom: 0;
+  //   right: 5vw;
+  //   display: flex;
+  // }
 `
-
+const NameTageContainer = styled.div`
+  display: flex;
+  margin-left: auto;
+  margin-right: auto;
+  flex-grow: 1;
+`
 const NameTag = ({ username }) => {
   const nameTagRef = useRef()
   const [nameWidth, setWidth] = useState(0)
@@ -95,12 +101,14 @@ const NameTag = ({ username }) => {
   }, [username])
   return (
     <>
-      <Nametag draggable={true}>
-        <Avatar src="https://static.tvtropes.org/pmwiki/pub/images/abcb6534_7913_4eb1_a7a5_62b081ebc628.png" />
-        <User ref={nameTagRef} width={nameWidth}>
-          {username}
-        </User>
-      </Nametag>
+      <NameTageContainer>
+        <Nametag draggable={true}>
+          <Avatar src="https://static.tvtropes.org/pmwiki/pub/images/abcb6534_7913_4eb1_a7a5_62b081ebc628.png" />
+          <User ref={nameTagRef} width={nameWidth}>
+            {username}
+          </User>
+        </Nametag>
+      </NameTageContainer>
     </>
   )
 }

--- a/src/components/NameTag.js
+++ b/src/components/NameTag.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { device } from '../worker/breakpoints'
 
@@ -12,18 +12,36 @@ const Avatar = styled.img`
   width: 4em;
   height: 4em;
 `
+
+const handleUserWidth = (props) => {
+  if (props.width > 119) {
+    return (props) => props.width - 3;
+  } else {
+    return 200;
+  }
+}
+
+const handleUserHeight = (props) => {
+  if (props.width > 119) {
+    return 2;
+  } else {
+    return 1
+  }
+}
+
+
 const User = styled.h1`
   position: absolute;
-  margin-right: auto;
-  margin-left: auto;
+  // margin-right: auto;
+  // margin-left: auto;
   font-style: normal;
   font-weight: 600;
-  font-size: 200%;
   display: flex;
   color: #ffffff;
-  font-size: 200%;
-    top: 1vh;
-    right: 15px;
+  font-size: ${handleUserWidth}%;
+  top: ${handleUserHeight}vh;
+  // margin-top: 0;
+  right: 15px;
   &:hover {
     cursor: context-menu;
   }
@@ -75,12 +93,19 @@ const Nametag = styled.div`
   }
 `
 
-const NameTag = ({ username, setUsername }) => {
+const NameTag = ({ username }) => {
+  const nameTagRef = useRef()
+  const [nameWidth, setWidth] = useState(0)
+  useEffect(() => {
+    setWidth(nameTagRef.current.offsetWidth)
+  }, [username])
   return (
     <>
       <Nametag draggable={true}>
         <Avatar src="https://static.tvtropes.org/pmwiki/pub/images/abcb6534_7913_4eb1_a7a5_62b081ebc628.png" />
-        <User>{username}</User>
+        <User ref={nameTagRef} width={nameWidth}>
+          {username}
+        </User>
       </Nametag>
     </>
   )

--- a/src/components/NameTag.js
+++ b/src/components/NameTag.js
@@ -33,7 +33,7 @@ const handleUserHeight = (props) => {
 const User = styled.h1`
   position: absolute;
   // margin-right: auto;
-  // margin-left: auto;
+  margin-left: auto;
   font-style: normal;
   font-weight: 600;
   display: flex;

--- a/src/components/NameTag.js
+++ b/src/components/NameTag.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import { device } from '../worker/breakpoints'
 

--- a/src/components/NameTag.js
+++ b/src/components/NameTag.js
@@ -15,24 +15,22 @@ const Avatar = styled.img`
 
 const handleUserWidth = (props) => {
   if (props.width > 119) {
-    return (props) => props.width - 3;
+    return (props) => props.width - 3
   } else {
-    return 200;
+    return 200
   }
 }
 
 const handleUserHeight = (props) => {
   if (props.width > 119) {
-    return 2;
+    return 2
   } else {
     return 1
   }
 }
 
-
 const User = styled.h1`
   position: absolute;
-  // margin-right: auto;
   margin-left: auto;
   font-style: normal;
   font-weight: 600;
@@ -40,11 +38,7 @@ const User = styled.h1`
   color: #ffffff;
   font-size: ${handleUserWidth}%;
   top: ${handleUserHeight}vh;
-  // margin-top: 0;
   right: 15px;
-  &:hover {
-    cursor: context-menu;
-  }
 `
 const Nametag = styled.div`
   border: solid 3px #505050;

--- a/src/components/NameTag.js
+++ b/src/components/NameTag.js
@@ -13,7 +13,7 @@ const Avatar = styled.img`
   height: 4em;
 `
 
-const handleUserWidth = (props) => {
+const handleUserFont = (props) => {
   if (props.width > 119) {
     return 150
   } else if (props.width > 135) {
@@ -24,23 +24,33 @@ const handleUserWidth = (props) => {
 }
 
 const handleUserHeight = (props) => {
-  if (props.width > 119) {
+  if (props.width > 130) {
     return 2
-  } else if (props.width > 135) {
+  } else if (props.width > 119) {
     return 1
   } else {
-    return 0
+    return 2.5
+  }
+}
+const handleUserWidth = (props) => {
+  if (props.width > 130) {
+    return 2
+  } else if (props.width > 119) {
+    return 1
+  } else {
+    return 2
   }
 }
 
 const User = styled.h1`
+  margin: 0 auto;
   position: absolute;
-  margin-left: 1.5vw;
+  margin-left: ${handleUserWidth}vw;
   font-style: normal;
   font-weight: 600;
-  display: flex;
+  // display: ;
   color: #ffffff;
-  font-size: ${handleUserWidth}%;
+  font-size: ${handleUserFont}%;
   top: ${handleUserHeight}vh;
   // right: 15px;
 `
@@ -103,6 +113,7 @@ const NameTag = ({ username }) => {
   const [nameWidth, setWidth] = useState(0)
   useEffect(() => {
     setWidth(nameTagRef.current.offsetWidth)
+    console.log(nameTagRef)
   }, [username])
   return (
     <>

--- a/src/components/NameTag.js
+++ b/src/components/NameTag.js
@@ -14,10 +14,12 @@ const Avatar = styled.img`
 `
 
 const handleUserFont = (props) => {
-  if (props.width > 119) {
+  if (props.width > 130) {
     return 150
-  } else if (props.width > 135) {
-    return 150
+  } else if (props.width > 122) {
+    return 160
+  } else if (props.width >= 119) {
+    return 180
   } else {
     return 250
   }
@@ -25,20 +27,25 @@ const handleUserFont = (props) => {
 
 const handleUserHeight = (props) => {
   if (props.width > 130) {
+    return 4
+  }
+   else if (props.width > 120) {
+    return 3
+  } 
+   else if (props.width > 119) {
     return 2
-  } else if (props.width > 119) {
-    return 1
-  } else {
+  } 
+  else {
     return 2.5
   }
 }
 const handleUserWidth = (props) => {
   if (props.width > 130) {
-    return 2
-  } else if (props.width > 119) {
     return 1
+  } else if (props.width >= 119) {
+    return 4
   } else {
-    return 2
+    return 2.5
   }
 }
 

--- a/src/components/NameTag.js
+++ b/src/components/NameTag.js
@@ -15,33 +15,38 @@ const Avatar = styled.img`
 
 const handleUserWidth = (props) => {
   if (props.width > 119) {
-    return (props) => props.width - 3
+    return 150
+  } else if (props.width > 135) {
+    return 150
   } else {
-    return 200
+    return 250
   }
 }
 
 const handleUserHeight = (props) => {
   if (props.width > 119) {
     return 2
-  } else {
+  } else if (props.width > 135) {
     return 1
+  } else {
+    return 0
   }
 }
 
 const User = styled.h1`
   position: absolute;
-  margin-left: auto;
+  margin-left: 1.5vw;
   font-style: normal;
   font-weight: 600;
   display: flex;
   color: #ffffff;
   font-size: ${handleUserWidth}%;
   top: ${handleUserHeight}vh;
-  right: 15px;
+  // right: 15px;
 `
 const Nametag = styled.div`
-display: flex;
+  display: flex;
+  justify-content: space-between;
   border: solid 3px #505050;
   background: #696969;
   position: fixed;

--- a/src/components/NavMapper.js
+++ b/src/components/NavMapper.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import { device } from '../worker/breakpoints'
-import { TbMessageCircle2 } from 'react-icons/tb'
+import { AiOutlineAlert} from 'react-icons/ai'
 
 const NavbarLink = styled(Link)`
   color: #ffffff;
@@ -35,50 +35,76 @@ const NavbarLink = styled(Link)`
   }
 `
 
-const Badge = styled(TbMessageCircle2)`
-  margin-left: 1em;
-  color: #ffffff;
-  margin-top: -1.5em;
-  font-size: 1rem;
-  transform: rotateZ(90deg) rotate(0.5turn);
-  @media only screen and ${device.xs} {
-  }
-  @media only screen and ${device.sm} {
-  }
-  @media only screen and ${device.md} {
-    margin-left: 0.1em;
-  }
-  @media only screen and ${device.lg} {
-    margin-left: 0.1em;
-  }
-  @media only screen and ${device.xlg} {
-    font-size: 1rem;
-    margin-left: 1em;
-  }
-`
+// const Badge = styled(TbMessageCircle2)`
+//   margin-left: 1em;
+//   color: #ffffff;
+//   margin-top: -1.5em;
+//   font-size: 1rem;
+//   transform: rotateZ(90deg) rotate(0.5turn);
+//   @media only screen and ${device.xs} {
+//   }
+//   @media only screen and ${device.sm} {
+//   }
+//   @media only screen and ${device.md} {
+//     margin-left: 0.1em;
+//   }
+//   @media only screen and ${device.lg} {
+//     margin-left: 0.1em;
+//   }
+//   @media only screen and ${device.xlg} {
+//     font-size: 1rem;
+//     margin-left: 1em;
+//   }
+// `
 
-const BadgeNumber = styled.p`
-  margin-left: 2.2em;
-  margin-top: -1.6em;
-  font-size: 0.6em;
-  width: 25%;
-  color: #ffffff;
-  text-shadow: #ffffff 0.5px 0 2.5px;
+// const BadgeNumber = styled.p`
+//   margin-left: 2.2em;
+//   margin-top: -1.6em;
+//   font-size: 0.6em;
+//   width: 25%;
+//   color: #ffffff;
+//   text-shadow: #ffffff 0.5px 0 2.5px;
+//   @media only screen and ${device.xs} {
+//   }
+//   @media only screen and ${device.sm} {
+//   }
+//   @media only screen and ${device.md} {
+//     margin-left: 0.8em;
+//     font-sze: 2em;
+//   }
+//   @media only screen and ${device.lg} {
+//     margin-left: 0.8em;
+//     font-sze: 2em;
+//   }
+//   @media only screen and ${device.xlg} {
+//     margin-left: 2.2em;
+//     font-size: 0.6em;
+//   }
+// `
+
+const Badge = styled(AiOutlineAlert)`
+  color: #1a8cff;
+  display: block;
+  position: fixed;
+  left: 0.5em;
+  font-size: 0.8rem;
+  // transform: rotateZ(90deg) rotate(0.5turn);
   @media only screen and ${device.xs} {
   }
   @media only screen and ${device.sm} {
   }
   @media only screen and ${device.md} {
-    margin-left: 0.8em;
-    font-sze: 2em;
+    margin-left: 0.1em;
+    font-size: 0.8rem;
   }
   @media only screen and ${device.lg} {
-    margin-left: 0.8em;
-    font-sze: 2em;
+    margin-left: 0.1em;
+    font-size: 0.8rem;
   }
   @media only screen and ${device.xlg} {
-    margin-left: 2.2em;
-    font-size: 0.6em;
+    font-size: 0.8rem;
+    margin-left: 1.3em;
+    // margin-top: -.1em;
   }
 `
 
@@ -89,6 +115,10 @@ const NavMapper = ({
   handleMouseOut,
   handleNotifCount,
 }) => {
+
+  // const handleClick = 
+
+
   return friends.map(
     ({ name, id, avatar, unread, online }, i) =>
       online === '1' &&
@@ -99,13 +129,13 @@ const NavMapper = ({
               friendRefs.current[i] = ref
             }}
             key={id}
-            onMouseOver={() => handleMouseOver(id, name, avatar, i)}
-            onMouseOut={handleMouseOut}
+            // onMouseOver={() => handleMouseOver(id, name, avatar, i)}
+            // onMouseOut={handleMouseOut}
           >
+            {unread > 0 && <Badge />}
             {name}
           </NavbarLink>
-          {unread > 0 && <Badge />}
-          {unread > 0 && <BadgeNumber>{handleNotifCount(unread)}</BadgeNumber>}
+          {/* {unread > 0 && <BadgeNumber>{}</BadgeNumber>} */}
         </>
       )
   )

--- a/src/components/NavMapper.js
+++ b/src/components/NavMapper.js
@@ -5,37 +5,6 @@ import { device } from '../worker/breakpoints'
 import { AiOutlineAlert } from 'react-icons/ai'
 import { ChatContext } from '../context/ChatContext'
 
-const NavbarLink = styled(Link)`
-  color: #ffffff;
-  font-style: normal;
-  font-weight: 700;
-  margin-left: 2em;
-  text-decoration: none;
-  margin-top: 0.5em;
-  margin-bottom: auto;
-  &:hover {
-    text-shadow: #ffffff 0.5px 0 2.5px;
-  }
-  @media only screen and ${device.xs} {
-    font-size: x-small;
-  }
-  @media only screen and ${device.sm} {
-    font-size: small;
-  }
-  @media only screen and ${device.md} {
-    margin-left: 1.2em;
-    font-size: medium;
-  }
-  @media only screen and ${device.lg} {
-    margin-left: 1.2em;
-    font-sze: medium;
-  }
-  @media only screen and ${device.xlg} {
-    font-size: large;
-    margin-left: 2em;
-  }
-`
-
 // const Badge = styled(TbMessageCircle2)`
 //   margin-left: 1em;
 //   color: #ffffff;
@@ -82,31 +51,27 @@ const NavbarLink = styled(Link)`
 //     font-size: 0.6em;
 //   }
 // `
+const NavbarLink = styled(Link)`
+  color: #ffffff;
+  font-style: normal;
+  font-weight: 700;
+  text-decoration: none;
+  margin-top: 0.5em;
+  margin-bottom: auto;
+  font-size: large;
+  margin-left: 2em;
+  &:hover {
+    text-shadow: #ffffff 0.5px 0 2.5px;
+  }
+`
 
 const Badge = styled(AiOutlineAlert)`
   color: #1a8cff;
   display: block;
   position: fixed;
-  right: 28em;
-  font-size: 0.5rem;
-  // transform: rotateZ(90deg) rotate(0.5turn);
-  @media only screen and ${device.xs} {
-  }
-  @media only screen and ${device.sm} {
-  }
-  @media only screen and ${device.md} {
-    margin-left: 0.1em;
-    font-size: 0.8rem;
-  }
-  @media only screen and ${device.lg} {
-    margin-left: 0.1em;
-    font-size: 0.8rem;
-  }
-  @media only screen and ${device.xlg} {
-    font-size: 0.8rem;
-    margin-left: 1.3em;
-    // margin-top: -.1em;
-  }
+  font-size: 0.8rem;
+  margin-left: 2em;
+  right: 213px;
 `
 
 const NavMapper = ({

--- a/src/components/NavMapper.js
+++ b/src/components/NavMapper.js
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import { device } from '../worker/breakpoints'
-import { AiOutlineAlert} from 'react-icons/ai'
+import { AiOutlineAlert } from 'react-icons/ai'
+import { ChatContext } from '../context/ChatContext'
 
 const NavbarLink = styled(Link)`
   color: #ffffff;
@@ -86,8 +87,8 @@ const Badge = styled(AiOutlineAlert)`
   color: #1a8cff;
   display: block;
   position: fixed;
-  left: 0.5em;
-  font-size: 0.8rem;
+  right: 28em;
+  font-size: 0.5rem;
   // transform: rotateZ(90deg) rotate(0.5turn);
   @media only screen and ${device.xs} {
   }
@@ -115,27 +116,44 @@ const NavMapper = ({
   handleMouseOut,
   handleNotifCount,
 }) => {
+  const { handleChatStateChange, setInboxView } = useContext(ChatContext)
 
-  // const handleClick = 
-
+  const handleClick = () => {
+    setInboxView(true)
+    handleChatStateChange()
+  }
 
   return friends.map(
-    ({ name, id, avatar, unread, online }, i) =>
-      online === '1' &&
-      unread > 0 && (
+    ({ name, id, avatar, unread, online, bio }, i) =>
+      online === '1' && (
         <>
-          <NavbarLink
-            ref={(ref) => {
-              friendRefs.current[i] = ref
-            }}
-            key={id}
-            // onMouseOver={() => handleMouseOver(id, name, avatar, i)}
-            // onMouseOut={handleMouseOut}
-          >
-            {unread > 0 && <Badge />}
-            {name}
-          </NavbarLink>
-          {/* {unread > 0 && <BadgeNumber>{}</BadgeNumber>} */}
+          {unread > 0 ? (
+            <NavbarLink
+              ref={(ref) => {
+                friendRefs.current[i] = ref
+              }}
+              key={id}
+              // onMouseOver={() => handleMouseOver(id, name, avatar, bio, i)}
+              // onMouseOut={handleMouseOut}
+              onClick={handleClick}
+            >
+              {unread > 0 && <Badge />}
+              {name}
+            </NavbarLink>
+          ) : (
+            <NavbarLink
+              ref={(ref) => {
+                friendRefs.current[i] = ref
+              }}
+              key={id}
+              // onMouseOver={() => handleMouseOver(id, name, avatar, bio, i)}
+              // onMouseOut={handleMouseOut}
+              onClick={() => {}}
+            >
+              {unread > 0 && <Badge />}
+              {name}
+            </NavbarLink>
+          )}
         </>
       )
   )

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -39,8 +39,11 @@ const NavString = styled.p`
   margin-bottom: 0;
   margin-left: 1em;
   margin-top: 0.3em;
+  :not(:disabled) {
+    cursor: pointer;
+  }
   &:hover {
-    cursor: context-menu;
+    text-shadow: #ffffff 0.5px 0 2.5px;
   }
   @media only screen and ${device.xs} {
     font-size: x-small;
@@ -69,7 +72,7 @@ const ChatterContainer = styled.div`
   position: fixed;
 `
 const NavbarLinkContainer = styled.div`
-  margin-top: 4em;
+  margin-top: 5em;
   display: flex;
   flex-direction: column;
   width: 3em;
@@ -84,6 +87,7 @@ const NavbarLink = styled(Link)`
   text-decoration: none;
   margin-top: 0.5em;
   margin-bottom: auto;
+  cursor: pointer;
   &:hover {
     text-shadow: #ffffff 0.5px 0 2.5px;
   }
@@ -167,7 +171,8 @@ const SideNav = () => {
   */
   const friendRefs = useRef([])
   const { username, setUsername } = useContext(UserContext)
-  const { handleChatStateChange, setOpenMini, setNav } = useContext(ChatContext)
+  const { handleChatStateChange, setOpenMini, setNav, setInboxView } =
+    useContext(ChatContext)
   const {
     setFriendName,
     setAvatar,
@@ -207,6 +212,10 @@ const SideNav = () => {
     return unread < 10 ? unread : '+'
   }
 
+  const handleClick = () => {
+    setInboxView(true)
+    handleChatStateChange()
+  }
   /*
     NavbarLink components have hoverable capabalities.
     onMouseOver and onMouseOut handle the dom events for us.  
@@ -223,9 +232,10 @@ const SideNav = () => {
     <Navbar>
       <ChatterContainer>
         <NavString>Friends</NavString>
+        <NavString onClick={handleClick}>Inbox</NavString>
       </ChatterContainer>
       <NavbarLinkContainer>
-        <NavString>Online</NavString>
+        <NavString disabled>Online</NavString>
         {Friends.map(
           ({ name, id, avatar, unread, online, bio }, i) =>
             online === '1' && (
@@ -240,7 +250,7 @@ const SideNav = () => {
                       handleMouseOver(id, name, avatar, bio, i)
                     }
                     onMouseOut={handleMouseOut}
-                    onClick={handleChatStateChange}
+                    onClick={handleClick}
                   >
                     {unread > 0 && <Badge />}
                     {name}

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -230,21 +230,37 @@ const SideNav = () => {
           ({ name, id, avatar, unread, online, bio }, i) =>
             online === '1' && (
               <>
-                <NavbarLink
-                  ref={(ref) => {
-                    friendRefs.current[i] = ref
-                  }}
-                  key={id}
-                  onMouseOver={() => handleMouseOver(id, name, avatar, bio, i)}
-                  onMouseOut={handleMouseOut}
-                  onClick={handleChatStateChange}
-                >
-                  {unread > 0 && <Badge />}
-                  {name}
-                </NavbarLink>
-                {/* {unread > 0 && (
-                  <BadgeNumber>{handleNotifCount(unread)}</BadgeNumber>
-                )} */}
+                {unread > 0 ? (
+                  <NavbarLink
+                    ref={(ref) => {
+                      friendRefs.current[i] = ref
+                    }}
+                    key={id}
+                    onMouseOver={() =>
+                      handleMouseOver(id, name, avatar, bio, i)
+                    }
+                    onMouseOut={handleMouseOut}
+                    onClick={handleChatStateChange}
+                  >
+                    {unread > 0 && <Badge />}
+                    {name}
+                  </NavbarLink>
+                ) : (
+                  <NavbarLink
+                    ref={(ref) => {
+                      friendRefs.current[i] = ref
+                    }}
+                    key={id}
+                    onMouseOver={() =>
+                      handleMouseOver(id, name, avatar, bio, i)
+                    }
+                    onMouseOut={handleMouseOut}
+                    onClick={() => {}}
+                  >
+                    {unread > 0 && <Badge />}
+                    {name}
+                  </NavbarLink>
+                )}
               </>
             )
         )}
@@ -255,6 +271,9 @@ const SideNav = () => {
           handleMouseOut={handleMouseOut}
           handleNotifCount={handleNotifCount}
         /> */}
+        {/* {unread > 0 && (
+              <BadgeNumber>{handleNotifCount(unread)}</BadgeNumber>
+            )} */}
       </NavbarLinkContainer>
       <UserMenu username={username} setUsername={setUsername} />
     </Navbar>

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -168,20 +168,27 @@ const SideNav = () => {
   const friendRefs = useRef([])
   const { username, setUsername } = useContext(UserContext)
   const { handleChatStateChange, setOpenMini, setNav } = useContext(ChatContext)
-  const { setFriendName, setAvatar, setOffsetLeft, setOffsetTop, getUnread } =
-    useContext(FriendContext)
+  const {
+    setFriendName,
+    setAvatar,
+    setOffsetLeft,
+    setOffsetTop,
+    getUnread,
+    setBio,
+  } = useContext(FriendContext)
   /*
     handleMouseOver and handleMouseOut funtsions handle the
     hover events for displaying the modal and 
     setting required data for modal.
    */
 
-  function handleMouseOver(id, name, avatar, i) {
+  function handleMouseOver(id, name, avatar, bio, i) {
     setNav('side')
     getUnread(id, Friends)
     setOpenMini(true)
     setFriendName(name)
     setAvatar(avatar)
+    setBio(bio)
     setOffsetLeft(friendRefs.current[i].offsetLeft)
     setOffsetTop(friendRefs.current[i].offsetTop)
   }
@@ -191,6 +198,7 @@ const SideNav = () => {
     setOpenMini(false)
     setFriendName('')
     setAvatar('')
+    setBio('')
     setOffsetLeft(0)
     setOffsetTop(0)
   }
@@ -219,7 +227,7 @@ const SideNav = () => {
       <NavbarLinkContainer>
         <NavString>Online</NavString>
         {Friends.map(
-          ({ name, id, avatar, unread, online }, i) =>
+          ({ name, id, avatar, unread, online, bio }, i) =>
             online === '1' && (
               <>
                 <NavbarLink
@@ -227,7 +235,7 @@ const SideNav = () => {
                     friendRefs.current[i] = ref
                   }}
                   key={id}
-                  onMouseOver={() => handleMouseOver(id, name, avatar, i)}
+                  onMouseOver={() => handleMouseOver(id, name, avatar, bio, i)}
                   onMouseOut={handleMouseOut}
                   onClick={handleChatStateChange}
                 >

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -7,12 +7,13 @@ import { ChatContext } from '../context/ChatContext'
 import { Friends } from '../worker/FakeData'
 import UserMenu from './UserMenu'
 import { TbMessageCircle2 } from 'react-icons/tb'
+import { AiOutlineAlert } from 'react-icons/ai'
 import { device } from '../worker/breakpoints'
 import NavMapper from './NavMapper'
 
 const Navbar = styled.nav`
   position: sticky;
-  width: 10vw;
+  width: 12vw;
   height: auto;
   background: #404040;
   border-right: solid 1px #505050;
@@ -106,51 +107,56 @@ const NavbarLink = styled(Link)`
   }
 `
 
-const Badge = styled(TbMessageCircle2)`
-  color: #ffffff;
-  margin-top: -1.5em;
-  font-size: 1rem;
-  transform: rotateZ(90deg) rotate(0.5turn);
+const Badge = styled(AiOutlineAlert)`
+  color: #1a8cff;
+  display: block;
+  position: fixed;
+  left: 0.5em;
+  font-size: 0.8rem;
+  // transform: rotateZ(90deg) rotate(0.5turn);
   @media only screen and ${device.xs} {
   }
   @media only screen and ${device.sm} {
   }
   @media only screen and ${device.md} {
     margin-left: 0.1em;
+    font-size: 0.8rem;
   }
   @media only screen and ${device.lg} {
     margin-left: 0.1em;
+    font-size: 0.8rem;
   }
   @media only screen and ${device.xlg} {
-    font-size: 1rem;
-    margin-left: 1em;
+    font-size: 0.8rem;
+    margin-left: 1.3em;
+    // margin-top: -.1em;
   }
 `
 
-const BadgeNumber = styled.p`
-  margin-left: 2.2em;
-  margin-top: -1.6em;
-  font-size: 0.6em;
-  width: 25%;
-  color: #ffffff;
-  text-shadow: #ffffff 0.5px 0 2.5px;
-  @media only screen and ${device.xs} {
-  }
-  @media only screen and ${device.sm} {
-  }
-  @media only screen and ${device.md} {
-    margin-left: 0.8em;
-    font-sze: 2em;
-  }
-  @media only screen and ${device.lg} {
-    margin-left: 0.8em;
-    font-sze: 2em;
-  }
-  @media only screen and ${device.xlg} {
-    margin-left: 2.2em;
-    font-size: 0.6em;
-  }
-`
+// const BadgeNumber = styled.p`
+//   margin-left: 2.2em;
+//   margin-top: -1.6em;
+//   font-size: 0.6em;
+//   width: 25%;
+//   color: #ffffff;
+//   text-shadow: #ffffff 0.5px 0 2.5px;
+//   @media only screen and ${device.xs} {
+//   }
+//   @media only screen and ${device.sm} {
+//   }
+//   @media only screen and ${device.md} {
+//     margin-left: 0.8em;
+//     font-sze: 2em;
+//   }
+//   @media only screen and ${device.lg} {
+//     margin-left: 0.8em;
+//     font-sze: 2em;
+//   }
+//   @media only screen and ${device.xlg} {
+//     margin-left: 2.2em;
+//     font-size: 0.6em;
+//   }
+// `
 const SideNav = () => {
   /*
     friendRefs is an array holding refs to elements in the side navbar.
@@ -171,7 +177,7 @@ const SideNav = () => {
    */
 
   function handleMouseOver(id, name, avatar, i) {
-    setNav('side');
+    setNav('side')
     getUnread(id, Friends)
     setOpenMini(true)
     setFriendName(name)
@@ -181,7 +187,7 @@ const SideNav = () => {
   }
 
   const handleMouseOut = () => {
-    setNav('');
+    setNav('')
     setOpenMini(false)
     setFriendName('')
     setAvatar('')
@@ -214,8 +220,7 @@ const SideNav = () => {
         <NavString>Online</NavString>
         {Friends.map(
           ({ name, id, avatar, unread, online }, i) =>
-            online === '1' &&
-            unread > 0 && (
+            online === '1' && (
               <>
                 <NavbarLink
                   ref={(ref) => {
@@ -226,12 +231,12 @@ const SideNav = () => {
                   onMouseOut={handleMouseOut}
                   onClick={handleChatStateChange}
                 >
+                  {unread > 0 && <Badge />}
                   {name}
                 </NavbarLink>
-                {unread > 0 && <Badge />}
-                {unread > 0 && (
+                {/* {unread > 0 && (
                   <BadgeNumber>{handleNotifCount(unread)}</BadgeNumber>
-                )}
+                )} */}
               </>
             )
         )}

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -151,7 +151,7 @@ const BadgeNumber = styled.p`
     font-size: 0.6em;
   }
 `
-const SideNav = ({ open, setOpen }) => {
+const SideNav = () => {
   /*
     friendRefs is an array holding refs to elements in the side navbar.
     I use the setOffsetLeft and setOffsetTop context functions to 
@@ -161,7 +161,7 @@ const SideNav = ({ open, setOpen }) => {
   */
   const friendRefs = useRef([])
   const { username, setUsername } = useContext(UserContext)
-  const { handleChatStateChange, openChat } = useContext(ChatContext)
+  const { handleChatStateChange, setOpenMini, setNav } = useContext(ChatContext)
   const { setFriendName, setAvatar, setOffsetLeft, setOffsetTop, getUnread } =
     useContext(FriendContext)
   /*
@@ -171,8 +171,9 @@ const SideNav = ({ open, setOpen }) => {
    */
 
   function handleMouseOver(id, name, avatar, i) {
+    setNav('side');
     getUnread(id, Friends)
-    setOpen(true)
+    setOpenMini(true)
     setFriendName(name)
     setAvatar(avatar)
     setOffsetLeft(friendRefs.current[i].offsetLeft)
@@ -180,7 +181,8 @@ const SideNav = ({ open, setOpen }) => {
   }
 
   const handleMouseOut = () => {
-    setOpen(false)
+    setNav('');
+    setOpenMini(false)
     setFriendName('')
     setAvatar('')
     setOffsetLeft(0)

--- a/src/components/UserMenu.js
+++ b/src/components/UserMenu.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
-import { HiOutlineLogout } from 'react-icons/hi'
+import { TbLogout } from 'react-icons/tb'
 import { device } from '../worker/breakpoints'
 
 const UserMenuContainer = styled.div`
@@ -156,7 +156,7 @@ const UserMenu = ({ username, setUsername }) => {
       <UserMenuContainer>
         <User>{username}</User>
         <LogoutButton>
-          <HiOutlineLogout onClick={handleLogout} />
+          <TbLogout onClick={handleLogout} />
         </LogoutButton>
       </UserMenuContainer>
     </>

--- a/src/components/UserMenu.js
+++ b/src/components/UserMenu.js
@@ -59,18 +59,25 @@ const User = styled.p`
     margin: auto;
   }
   @media only screen and ${device.sm} {
-    font-size: small;
+    font-size: x-small;
     margin-left: 0;
     margin: auto;
   }
   @media only screen and ${device.md} {
+    font-size: x-small;
+    margin: auto;
+  }
+
+  @media only screen and ${device.lg} {
     font-size: small;
+    margin-left: 0.5em;
     margin: auto;
   }
 
   @media only screen and ${device.xlg} {
     font-size: medium;
     margin-left: 0.5em;
+    margin: auto;
   }
 `
 

--- a/src/components/UserMenu.js
+++ b/src/components/UserMenu.js
@@ -8,7 +8,7 @@ const UserMenuContainer = styled.div`
   display: flex;
   position: fixed;
   bottom: 0;
-  width: 10vw;
+  width: 12%;
   flex-direction: row;
   justify-content: space-between;
   border: solid 1px DimGrey;
@@ -61,12 +61,12 @@ const User = styled.p`
     margin: auto;
   }
   @media only screen and ${device.md} {
-    font-size: x-small;
+    font-size: small;
     margin: auto;
   }
 
   @media only screen and ${device.lg} {
-    font-size: small;
+    font-size: medium;
     margin-left: 0.5em;
     margin: auto;
   }

--- a/src/components/UserMenu.js
+++ b/src/components/UserMenu.js
@@ -51,9 +51,6 @@ const User = styled.p`
   font-style: normal;
   font-weight: 600;
   margin-left: 0.5em;
-  &:hover {
-    cursor: context-menu;
-  }
   @media only screen and ${device.xs} {
     font-size: x-small;
     margin: auto;
@@ -104,44 +101,6 @@ const LogoutButton = styled.button`
     width: 3em;
   }
 `
-
-//  const Logout = styled.button`
-//   height: 2em;
-//   width: 8em;
-//   position: absolute;
-//   top: 10vh;
-//   right: 3vw;
-//   background: #1a8cff;
-//   border: none;
-//   color: white;
-//   border-radius: 8px;
-//   :not(:disabled) {
-//     cursor: pointer;
-//   }
-//   &:hover {
-//     box-shadow: 0px 2px 7px #1a8cff;
-//   }
-//   @media only screen and ${device.xs} {
-//     height: 1em;
-//     width: 5em;
-//     right: 1vw;
-//     top: 6vh;
-//   }
-//   @media only screen and ${device.sm} {
-//     height: 2em;
-//     width: 8em;
-//     top: 10vh;
-//   }
-//   @media only screen and ${device.md} {
-//     display: none;
-//   }
-//   @media only screen and ${device.lg} {
-//     display: none;
-//   }
-//   @media only screen and ${device.xlg} {
-//     display: none;
-//   }
-// `
 
 const UserMenu = ({ username, setUsername }) => {
   const navigate = useNavigate()

--- a/src/context/ChatContext.js
+++ b/src/context/ChatContext.js
@@ -3,10 +3,16 @@ const ChatContext = createContext({
   openChat: false,
   setOpenChat: () => {},
   handleChatStateChange: () => {},
+  openMiniModal: false,
+  setOpenMini: () => {},
+  nav: '',
+  setNav: () => {},
 })
 
 export function ChatProvider({ children }) {
+  const [nav, setNav] = useState('')
   const [openChat, setOpenChat] = useState(false)
+  const [openMiniModal, setOpenMini] = useState(false)
 
   function handleChatStateChange(id, friends) {
     setOpenChat(!openChat)
@@ -14,8 +20,12 @@ export function ChatProvider({ children }) {
 
   const contextValue = {
     openChat: openChat,
-    setOpenChat: setOpenChat,
-    handleChatStateChange: handleChatStateChange,
+    setOpenChat,
+    handleChatStateChange,
+    openMiniModal: openMiniModal,
+    setOpenMini,
+    nav: nav,
+    setNav,
   }
 
   return (

--- a/src/context/ChatContext.js
+++ b/src/context/ChatContext.js
@@ -7,12 +7,15 @@ const ChatContext = createContext({
   setOpenMini: () => {},
   nav: '',
   setNav: () => {},
+  inboxView: true,
+  setInboxView: () => {},
 })
 
 export function ChatProvider({ children }) {
   const [nav, setNav] = useState('')
   const [openChat, setOpenChat] = useState(false)
   const [openMiniModal, setOpenMini] = useState(false)
+  const [inboxView, setInboxView] = useState(false)
 
   function handleChatStateChange(id, friends) {
     setOpenChat(!openChat)
@@ -26,6 +29,8 @@ export function ChatProvider({ children }) {
     setOpenMini,
     nav: nav,
     setNav,
+    inboxView: inboxView,
+    setInboxView,
   }
 
   return (

--- a/src/context/FriendContext.js
+++ b/src/context/FriendContext.js
@@ -13,6 +13,9 @@ const FriendContext = createContext({
   setOffsetTop: () => {},
   getUnread: () => {},
   handleNotifCount: () => {},
+  getMessages: () => {},
+  messages: [],
+  setMessages: () => {},
 })
 
 export function FriendProvider({ children }) {
@@ -21,6 +24,7 @@ export function FriendProvider({ children }) {
   const [unreadMessages, setUnreadMessages] = useState([])
   const [offsetLeft, setOffsetLeft] = useState(0)
   const [offsetTop, setOffsetTop] = useState(0)
+  const [messages, setMessages] = useState([])
 
   const getUnread = (id, friends) => {
     const friend = friends.find((friend) => friend.id === id)
@@ -38,6 +42,11 @@ export function FriendProvider({ children }) {
     return unread < 10 ? unread : '+'
   }
 
+  const getMessages = (id, friends) => {
+    const friend = friends.find((friend) => friend.id === id)
+    setMessages(friend.messages)
+  }
+
   const contextValue = {
     friendName: friendName,
     setFriendName,
@@ -50,7 +59,10 @@ export function FriendProvider({ children }) {
     offsetTop: offsetTop,
     setOffsetTop,
     getUnread,
-    handleNotifCount
+    handleNotifCount,
+    getMessages,
+    messages: messages,
+    setMessages,
   }
   return (
     <FriendContext.Provider value={contextValue}>

--- a/src/context/FriendContext.js
+++ b/src/context/FriendContext.js
@@ -16,6 +16,8 @@ const FriendContext = createContext({
   getMessages: () => {},
   messages: [],
   setMessages: () => {},
+  bio: '',
+  setBio: () => {},
 })
 
 export function FriendProvider({ children }) {
@@ -25,6 +27,7 @@ export function FriendProvider({ children }) {
   const [offsetLeft, setOffsetLeft] = useState(0)
   const [offsetTop, setOffsetTop] = useState(0)
   const [messages, setMessages] = useState([])
+  const [friendBio, setBio] = useState('')
 
   const getUnread = (id, friends) => {
     const friend = friends.find((friend) => friend.id === id)
@@ -63,6 +66,8 @@ export function FriendProvider({ children }) {
     getMessages,
     messages: messages,
     setMessages,
+    bio: friendBio,
+    setBio,
   }
   return (
     <FriendContext.Provider value={contextValue}>

--- a/src/context/UserContext.js
+++ b/src/context/UserContext.js
@@ -1,4 +1,5 @@
-import React, { createContext, useState } from 'react'
+import React, { createContext, useState, useRef } from 'react'
+import useLocalStorageState from 'use-local-storage-state'
 const UserContext = createContext({
   username: '',
   createUser: () => {},
@@ -6,7 +7,9 @@ const UserContext = createContext({
 })
 
 export function UserProvider({ children }) {
-  const [username, setUsername] = useState('Michael')
+  const [username, setUsername] = useLocalStorageState('userName', {
+    defaultValue: '',
+  })
 
   const createUser = (userName) => {
     if (username === userName) {

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -28,12 +28,12 @@ const Header = styled.h1`
   }
   @media only screen and ${device.md} {
     font-size: 300%;
-    margin-left: 15vw;
+    margin-left: 17vw;
     margin-top: 5vh;
   }
   @media only screen and ${device.lg} {
     font-size: 300%;
-    margin-left: 15vw;
+    margin-left: 17vw;
     margin-top: 5vh;
   }
 `

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -17,8 +17,8 @@ const Header = styled.h1`
   margin-top: 5vh;
   color: #ff6b00;
   @media only screen and ${device.xs} {
-    margin-left: 11vw;
-    margin-top: 6.5vh;
+    margin-left: 9vw;
+    margin-top: 6.3vh;
     font-size: 250%;
   }
   @media only screen and ${device.sm} {

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -16,9 +16,6 @@ const Header = styled.h1`
   margin-left: 15vw;
   margin-top: 5vh;
   color: #ff6b00;
-  &:hover {
-    cursor: context-menu;
-  }
   @media only screen and ${device.xs} {
     margin-left: 11vw;
     margin-top: 6.5vh;
@@ -38,36 +35,6 @@ const Header = styled.h1`
     font-size: 300%;
     margin-left: 15vw;
     margin-top: 5vh;
-  }
-`
-
-const ConditionalNav = styled.div`
-  border: solid 3px #505050;
-  background: SlateGray;
-  position: fixed;
-  right: 7vw;
-  top: 60vh;
-  margin-left: auto;
-  margin-right: auto;
-  width: 5vw;
-  height: 10vh;
-  padding: 5em;
-  border-radius: 8px;
-  @media only screen and ${device.xs} {
-    display: flex;
-    right: 6vw;
-    width: 0.3em;
-  }
-  @media only screen and ${device.sm} {
-    display: flex;
-    width: 4em;
-  }
-  @media only screen and ${device.md} {
-    display: none;
-  }
-  @media only screen and ${device.lg} {
-  }
-  @media only screen and ${device.xlg} {
   }
 `
 

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -5,11 +5,8 @@ import '../App.css'
 import { UserContext } from '../context/UserContext'
 import NameTag from '../components/NameTag'
 import { device } from '../worker/breakpoints'
-import UserMenu from '../components/UserMenu'
 import MainFeed from '../components/MainFeed'
 import ConditionalNavBar from '../components/ConditionalNavBar'
-import { ChatContext } from '../context/ChatContext'
-import FriendModal from '../components/FriendModal'
 
 const Header = styled.h1`
   position: absolute;
@@ -73,13 +70,9 @@ const ConditionalNav = styled.div`
   @media only screen and ${device.xlg} {
   }
 `
-// const DashboardContainer = styled.div`
-//   display: flex;
-//   flex-direction: row;
-// `
+
 const Dashboard = () => {
   const { username, setUsername } = useContext(UserContext)
-  const { openMiniModal } = useContext(ChatContext)
   return (
     <DashLayoutComponent>
       <Header>Messages</Header>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -8,6 +8,8 @@ import { device } from '../worker/breakpoints'
 import UserMenu from '../components/UserMenu'
 import MainFeed from '../components/MainFeed'
 import ConditionalNavBar from '../components/ConditionalNavBar'
+import { ChatContext } from '../context/ChatContext'
+import FriendModal from '../components/FriendModal'
 
 const Header = styled.h1`
   position: absolute;
@@ -77,6 +79,7 @@ const ConditionalNav = styled.div`
 // `
 const Dashboard = () => {
   const { username, setUsername } = useContext(UserContext)
+  const { openMiniModal } = useContext(ChatContext)
   return (
     <DashLayoutComponent>
       <Header>Messages</Header>

--- a/src/worker/FakeData.js
+++ b/src/worker/FakeData.js
@@ -475,6 +475,7 @@ const updatedFriendsList = (friends) => {
       message.timestamp = getRandomTime(i)
     })
     friend.online = '1'
+    friend.bio = `Hi, my name is ${friend.name}! Isn't Chatr great!`
   })
   return friends
 }

--- a/src/worker/FakeData.js
+++ b/src/worker/FakeData.js
@@ -1,3 +1,5 @@
+import { timeSwitch } from './timeSwitch'
+
 const friends = [
   {
     id: 'XUIASGASD99091',
@@ -455,16 +457,27 @@ const friends = [
   },
 ]
 
-export const updatedFriendsList = (friends) => {
+function getRandomTime(i) {
+  const hour = i === 0 ? timeSwitch(i) : i > 12 ? timeSwitch(i) : i
+  const meridiem = i > 12 ? 'pm' : 'am'
+  const minute = Math.floor(Math.random() * 60)
+  return minute.toString().length < 2
+    ? `${hour}:0${minute} ${meridiem}`
+    : `${hour}:${minute} ${meridiem}`
+}
+
+const updatedFriendsList = (friends) => {
   friends.forEach((friend) => {
-    friend.messages.forEach((message) => {
+    friend.messages.forEach((message, i) => {
       if (message.status !== 'read') {
         friend.unread++
       }
+      message.timestamp = getRandomTime(i)
     })
     friend.online = '1'
   })
   return friends
 }
 
+console.log(updatedFriendsList(friends))
 export const Friends = updatedFriendsList(friends)

--- a/src/worker/FakeData.js
+++ b/src/worker/FakeData.js
@@ -60,7 +60,7 @@ const friends = [
       },
       {
         id: 'mfmfhnfgif',
-        message: 'Lorem ipsum pueoa potreop nutromger retom yerid.',
+        message: 'Lorem ipsum pueoa potreop nutromger retom yerid. Hop flop de nop sop. Hitchie witchie banda wah, eaux sluh.',
         status: 'unread',
       },
     ],

--- a/src/worker/timeSwitch.js
+++ b/src/worker/timeSwitch.js
@@ -1,0 +1,32 @@
+export const timeSwitch = (expr) => {
+  switch (expr) {
+    case 0:
+      return 12
+    case 13:
+      return 1
+    case 14:
+      return 2
+    case 15:
+      return 3
+    case 16:
+      return 4
+    case 17:
+      return 5
+    case 18:
+      return 6
+    case 19:
+      return 7
+    case 20:
+      return 8
+    case 21:
+      return 9
+    case 22:
+      return 10
+    case 23:
+      return 11
+    case 24:
+      return 12
+    default:
+      return 'NaN'
+  }
+}


### PR DESCRIPTION
ConditionalNav in medium dimensions will close and open based on view. HandleChatStateChange and setInboxView allow the deck to be dynamic. setInboxView allows us to toggle back and forth between the two "views", and handleChatStateChange allows us to handle whether or not the deck will open or close accordingly. When the view is in the replacement for the sidenav, or Friends, the deck will have the state changed to false, but persist because of the media query. But the wider dimensions allow for the props to render based on a boolean, thus forcing it to close once the SN renders again. You can open it at this width, but you will not be given the friend view. That is only for when the sidenav is unreachable. In the future this will be iterated upon to allow to the user to directly click into their message and not just the inbox view.